### PR TITLE
Support for a CocoaPods-based install

### DIFF
--- a/ReactNativePermissions.podspec
+++ b/ReactNativePermissions.podspec
@@ -1,0 +1,21 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = 'ReactNativePermissions'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = package['description']
+  s.homepage            = package['homepage']
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/yonahforst/react-native-permissions.git', :tag => s.version }
+
+  s.platform            = :ios, '8.0'
+
+  s.dependency 'React'
+
+  s.preserve_paths      = 'docs', 'CHANGELOG.md', 'LICENSE', 'package.json', 'ReactNativePermissions.ios.js'
+  s.source_files        = '*.{h,m}'
+end

--- a/package.json
+++ b/package.json
@@ -8,5 +8,7 @@
   "license": "MIT",
   "keywords": ["react-native", "react-component"],
   "main": "ReactNativePermissions",
-  "author": "Yonah Forst <yonaforst@hotmail.com>"
+  "author": "Yonah Forst <yonaforst@hotmail.com>",
+  "homepage": "https://github.com/joshblour/react-native-permissions",
+  "description": "Check user permissions in React Native"
 }


### PR DESCRIPTION
Makes life easy if you're using CocoaPods to manage native dependencies; can just:

```
pod 'ReactNativePermissions', path: './node_modules/react-native-permissions'
```
