### PR TITLE
Podspec + Bugfix

### DIFF
--- a/ReactNativePermissions.js
+++ b/ReactNativePermissions.js
@@ -58,7 +58,7 @@ class ReactNativePermissions {
 
 
 	getPermissionStatus(permission) {
-  	if (RNPTypes.indexOf(permission) >= 0) {
+  	if (this.getPermissionTypes().indexOf(permission) >= 0) {
 			return RNPermissions.getPermissionStatus(permission)
 		} else {
 			return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on ${Platform.OS}`)

--- a/ReactNativePermissions.podspec
+++ b/ReactNativePermissions.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.dependency 'React'
 
   s.preserve_paths      = 'docs', 'CHANGELOG.md', 'LICENSE', 'package.json', 'ReactNativePermissions.ios.js'
-  s.source_files        = '*.{h,m}'
+  s.source_files        = '**/*.{h,m}'
 end


### PR DESCRIPTION
2 changes:
- In order to take advantage of your latest changes ( 👍 ), lets include the source files w/ podspec!
- It looks like you meant to check if permission was in `this.getPermissionTypes()` (array of permissions) not `RNPTypes`  (object of platforms to permissions).

Tested and I have it compiled & returning permissions on my dev iPhone.
