### PR TITLE
Update Readme (>= RN 0.29 for android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Permission type `bluetooth` represents the status of the `CBPeripheralManager`. 
 ```
 
 ###Android Notes
+
+**IMPORTANT:** You need at least React-Native 0.29 for Android in order to make this plugin work as expected.
 All required permissions also need to be included in the Manifest before they can be requested. Otherwise `requestPermission` will immediately return `denied`.
 
 Permissions are automatically accepted for targetSdkVersion < 23 but you can still use `getPermissionStatus` to check if the user has disabled them from Settings.


### PR DESCRIPTION
Hello,

Added in README the note that the plugin needs at least RN 0.29 for Android.  (issue #19)

Thx :)
