### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ android {
 }
 
 repositories {
+    maven { url "$projectDir/../../react-native/android" }
     jcenter()
 }
 


### PR DESCRIPTION
I was getting `react-native-permissions/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java:18: error: package com.facebook.react.modules.permissions does not exist
import com.facebook.react.modules.permissions.PermissionsModule;` because for some reason, the react-native version in the build directory was 0.20.1. This is because that is the latest version found [here ](https://bintray.com/bintray/jcenter/com.facebook.react:react-native/view)
