### PR TITLE
Android: Specify locale to toUpperCase call

### DIFF
--- a/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java
+++ b/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.modules.permissions.PermissionsModule;
 
+import java.util.Locale;
 
 public class ReactNativePermissionsModule extends ReactContextBaseJavaModule {
   private final ReactApplicationContext reactContext;
@@ -114,7 +115,7 @@ public class ReactNativePermissionsModule extends ReactContextBaseJavaModule {
   }
 
   private String permissionForString(String permission) {
-    switch (RNType.valueOf(permission.toUpperCase())) {
+    switch (RNType.valueOf(permission.toUpperCase(Locale.ENGLISH))) {
       case LOCATION:
         return Manifest.permission.ACCESS_FINE_LOCATION;
       case CAMERA:


### PR DESCRIPTION
Calls to `toUpperCase` uses device locale unless locale is specified.

This is causing some trouble on eg. Turkish devices, where `location` is upper-cased to `LOCATİON` causing a crash:

  `LOCATİON is not a constant in com.joshblour.reactnativepermissions.ReactNativePermissionsModule$RNType`

This PR solves the issue by specifying English as locale.
