### PR TITLE
Add npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+Example


### PR DESCRIPTION
`Example` should be ignored. It may causes XCode compile failed. 

https://facebook.github.io/react-native/docs/troubleshooting.html#argument-list-too-long-recursive-header-expansion-failed