### PR TITLE
fix for breaking iOS header change in RN 0.40.0

### DIFF
--- a/Example/ios/Example/AppDelegate.m
+++ b/Example/ios/Example/AppDelegate.m
@@ -9,8 +9,8 @@
 
 #import "AppDelegate.h"
 
-#import "RCTBundleURLProvider.h"
-#import "RCTRootView.h"
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
 
 @implementation AppDelegate
 

--- a/Example/ios/ExampleTests/ExampleTests.m
+++ b/Example/ios/ExampleTests/ExampleTests.m
@@ -10,8 +10,8 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "RCTLog.h"
-#import "RCTRootView.h"
+#import <React/RCTLog.h>
+#import <React/RCTRootView.h>
 
 #define TIMEOUT_SECONDS 600
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"

--- a/RCTConvert+RNPStatus.h
+++ b/RCTConvert+RNPStatus.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 static NSString* RNPStatusUndetermined = @"undetermined";
 static NSString* RNPStatusDenied = @"denied";

--- a/ReactNativePermissions.h
+++ b/ReactNativePermissions.h
@@ -5,7 +5,7 @@
 //  Created by Yonah Forst on 18/02/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 #import <Foundation/Foundation.h>
 

--- a/ReactNativePermissions.m
+++ b/ReactNativePermissions.m
@@ -10,9 +10,9 @@
 
 #import "ReactNativePermissions.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
 
 #import "RNPLocation.h"
 #import "RNPBluetooth.h"

--- a/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java
+++ b/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java
@@ -93,7 +93,7 @@ public class ReactNativePermissionsModule extends ReactContextBaseJavaModule {
         // NOOP
       }
     };
-    mPermissionsModule.requestPermission(permission, resolve, reject);
+    mPermissionsModule.requestPermission(permission, new PromiseImpl(resolve, reject));
   }
 
 


### PR DESCRIPTION
For the breaking "iOS native headers moved" [change in RN  0.40.0](https://github.com/facebook/react-native/releases/tag/v0.40.0).  Addresses facebook/react-native#11725.