### PR TITLE
Upgrade to React Native 0.40

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
-android/react-native-permissions.iml
-android/build
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+xcuserdata
+*.xccheckout
+DerivedData
+*.xcuserstate
+project.xcworkspace
+
+# Android/IntelliJ
+#
+build/
+.idea
+.gradle
+local.properties
+*.iml
+

--- a/Example/ios/Example/AppDelegate.m
+++ b/Example/ios/Example/AppDelegate.m
@@ -9,8 +9,8 @@
 
 #import "AppDelegate.h"
 
-#import "RCTBundleURLProvider.h"
-#import "RCTRootView.h"
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
 
 @implementation AppDelegate
 

--- a/Example/ios/ExampleTests/ExampleTests.m
+++ b/Example/ios/ExampleTests/ExampleTests.m
@@ -10,8 +10,8 @@
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
-#import "RCTLog.h"
-#import "RCTRootView.h"
+#import <React/RCTLog.h>
+#import <React/RCTRootView.h>
 
 #define TIMEOUT_SECONDS 600
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"

--- a/Example/package.json
+++ b/Example/package.json
@@ -6,8 +6,8 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "react": "15.2.1",
-    "react-native": "^0.30.0",
+    "react": "~15.4.0-rc.4",
+    "react-native": "^0.40.0",
     "react-native-permissions": "../"
   }
 }

--- a/RCTConvert+RNPStatus.h
+++ b/RCTConvert+RNPStatus.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import "RCTConvert.h"
+#import <React/RCTConvert.h>
 
 static NSString* RNPStatusUndetermined = @"undetermined";
 static NSString* RNPStatusDenied = @"denied";

--- a/ReactNativePermissions.h
+++ b/ReactNativePermissions.h
@@ -5,7 +5,7 @@
 //  Created by Yonah Forst on 18/02/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 #import <Foundation/Foundation.h>
 

--- a/ReactNativePermissions.m
+++ b/ReactNativePermissions.m
@@ -10,9 +10,9 @@
 
 #import "ReactNativePermissions.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
 
 #import "RNPLocation.h"
 #import "RNPBluetooth.h"

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "main": "ReactNativePermissions",
   "author": "Yonah Forst <yonaforst@hotmail.com>",
   "homepage": "https://github.com/joshblour/react-native-permissions",
-  "description": "Check user permissions in React Native"
+  "description": "Check user permissions in React Native",
+  "peerDependencies": {
+    "react-native": "^0.40.0"
+  }
 }


### PR DESCRIPTION
- Update with breaking iOS header path changes.
- Update package.json's accordingly to list peer depedency on React Native ^0.40.
- Add additional entries to .gitignore in accordance with React Native init's basic .gitignore.

See https://github.com/facebook/react-native/releases/tag/v0.40.0 for more information on the breaking changes for iOS React Native header imports. Note that this will likely break compatibility with React Native <0.40, which certainly could be problematic for some users. It's up to the maintainer - if <0.40 support is more important, than a separate branch could be made for 0.40+; if keeping up-to-date with React Native's latest is more important, then a note could be added to the README to point <0.40 users to a specific commit/branch before introducing these 0.40 fixes. Publishing releases might also be helpful here, with clear notes on which React Native versions are supported for each release. Thoughts?