### PR TITLE
Return Authorized in simulator

### DIFF
--- a/permissions/RNPAudioVideo.m
+++ b/permissions/RNPAudioVideo.m
@@ -13,18 +13,23 @@
 @implementation RNPAudioVideo
 
 + (NSString *)getStatus:(NSString *)type
-{
-    int status = [AVCaptureDevice authorizationStatusForMediaType:[self typeFromString:type]];
-    switch (status) {
-        case AVAuthorizationStatusAuthorized:
-            return RNPStatusAuthorized;
-        case AVAuthorizationStatusDenied:
-            return RNPStatusDenied;
-        case AVAuthorizationStatusRestricted:
-            return RNPStatusRestricted;
-        default:
-            return RNPStatusUndetermined;
-    }
+{   
+    #if TARGET_IPHONE_SIMULATOR
+        return RNPStatusAuthorized;
+    #else
+        int status = [AVCaptureDevice authorizationStatusForMediaType:[self typeFromString:type]];
+
+        switch (status) {
+            case AVAuthorizationStatusAuthorized:
+                return RNPStatusAuthorized;
+            case AVAuthorizationStatusDenied:
+                return RNPStatusDenied;
+            case AVAuthorizationStatusRestricted:
+                return RNPStatusRestricted;
+            default:
+                return RNPStatusUndetermined;
+        }
+    #endif
 }
 
 + (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler


### PR DESCRIPTION
In the iOS simulator the audio video permission is always granted. This makes it possible to test the code in the simulator.