### PR TITLE
Update build.gradle to lastest Android build tools

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Build Tools 25 are required in order to take advantage of Gradle 3.3, which has great performance improvements!