### PR TITLE
Fix after RN 4.0 breaking changes (e.g. 'React/RCTBridgeModule.h' file not found')

### DIFF
--- a/RCTConvert+RNPStatus.h
+++ b/RCTConvert+RNPStatus.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import <React/RCTConvert.h>
+#import <RCTConvert.h>
 
 static NSString* RNPStatusUndetermined = @"undetermined";
 static NSString* RNPStatusDenied = @"denied";

--- a/ReactNativePermissions.h
+++ b/ReactNativePermissions.h
@@ -5,7 +5,7 @@
 //  Created by Yonah Forst on 18/02/16.
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
-#import <React/RCTBridgeModule.h>
+#import <RCTBridgeModule.h>
 
 #import <Foundation/Foundation.h>
 

--- a/ReactNativePermissions.m
+++ b/ReactNativePermissions.m
@@ -12,7 +12,7 @@
 
 #import <RCTBridge.h>
 #import <RCTConvert.h>
-#import <RCTEventDispatcher.h>
+//#import <RCTEventDispatcher.h>
 
 #import "RNPLocation.h"
 #import "RNPBluetooth.h"

--- a/ReactNativePermissions.m
+++ b/ReactNativePermissions.m
@@ -10,9 +10,9 @@
 
 #import "ReactNativePermissions.h"
 
-#import <React/RCTBridge.h>
-#import <React/RCTConvert.h>
-#import <React/RCTEventDispatcher.h>
+#import <RCTBridge.h>
+#import <RCTConvert.h>
+#import <RCTEventDispatcher.h>
 
 #import "RNPLocation.h"
 #import "RNPBluetooth.h"

--- a/ReactNativePermissions.xcodeproj/project.pbxproj
+++ b/ReactNativePermissions.xcodeproj/project.pbxproj
@@ -280,9 +280,11 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../react-native/ReactCommon/**",
+					"$(SRCROOT)/../../react-native",
+					"ReactCommon/**",
+					"React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -295,9 +297,11 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../react-native/ReactCommon/**",
+					"$(SRCROOT)/../../react-native",
+					"ReactCommon/**",
+					"React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Fixes issue: #83 .Fixing the 'Header Search Path' in the XCode project allows the compiler to find the .h files without having to append a path to any include statement. This allows us to remove the 'React/' prefixes. It also fixes another related issue...Facebook made breaking changes in react-native by moving some files under new subdirectories which broke some of the 'React/' includes. 
