### PR TITLE
Fix when remote notifications are registered before user settings

### DIFF
--- a/permissions/RNPNotification.m
+++ b/permissions/RNPNotification.m
@@ -19,32 +19,32 @@ static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
 + (NSString *)getStatus
 {
     BOOL didAskForPermission = [[NSUserDefaults standardUserDefaults] boolForKey:RNPDidAskForNotification];
-    BOOL isRegistered = [[UIApplication sharedApplication] isRegisteredForRemoteNotifications];
     BOOL isEnabled = [[[UIApplication sharedApplication] currentUserNotificationSettings] types] != UIUserNotificationTypeNone;
-    
-    if (isRegistered || isEnabled) {
-        return isEnabled ? RNPStatusAuthorized : RNPStatusDenied;
+
+    if (isEnabled) {
+        return RNPStatusAuthorized;
     } else {
         return didAskForPermission ? RNPStatusDenied : RNPStatusUndetermined;
     }
 }
 
+
 - (void)request:(UIUserNotificationType)types completionHandler:(void (^)(NSString*))completionHandler
 {
     NSString *status = [self.class getStatus];
-    
+
     if (status == RNPStatusUndetermined) {
         self.completionHandler = completionHandler;
-        
+
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(applicationDidBecomeActive)
                                                      name:UIApplicationDidBecomeActiveNotification
                                                    object:nil];
-        
+
         UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:types categories:nil];
         [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
         [[UIApplication sharedApplication] registerForRemoteNotifications];
-        
+
         [[NSUserDefaults standardUserDefaults] setBool:YES forKey:RNPDidAskForNotification];
         [[NSUserDefaults standardUserDefaults] synchronize];
     } else {
@@ -57,7 +57,7 @@ static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
     [[NSNotificationCenter defaultCenter] removeObserver:self
                                                     name:UIApplicationDidBecomeActiveNotification
                                                   object:nil];
-    
+
     if (self.completionHandler) {
         //for some reason, checking permission right away returns denied. need to wait a tiny bit
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{


### PR DESCRIPTION
For example, when you register the device for remote notifications to
enable silent pushes `content-available: 1` and later ask the user for
the push permission but this function incorrectly returns `denied`.