### PR TITLE
Support Android 8 (O)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 24
+    compileSdkVersion 25
     buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Affects `react-native-linear-gradient:2.0.0`, `react-native-permissions:0.2.7`
```
* What went wrong:
A problem occurred configuring project ':app'.
> Could not resolve all dependencies for configuration ':app:_debugApk'.
   > A problem occurred configuring project ':react-native-linear-gradient'.
      > The SDK Build Tools revision (23.0.1) is too low for project ':react-native-linear-gradient'. Minimum required is 25.0.0
```

**Hotfix for existing project**:
```
    "fix0": "sed -i '' 's\/compileSdkVersion 23\/compileSdkVersion 25\/' ./node_modules/react-native-permissions/android/build.gradle",
    "fix1": "sed -i '' 's\/buildToolsVersion \"23.0.1\"\/buildToolsVersion \"25.0.0\"\/' ./node_modules/react-native-permissions/android/build.gradle",
    "fix2": "sed -i '' 's\/targetSdkVersion 23\/targetSdkVersion 25\/' ./node_modules/react-native-permissions/android/build.gradle",
    "fix3": "sed -i '' 's\/compileSdkVersion 23\/compileSdkVersion 25\/' ./node_modules/react-native-linear-gradient/android/build.gradle",
    "fix4": "sed -i '' 's\/buildToolsVersion \"23.0.1\"\/buildToolsVersion \"25.0.0\"\/' ./node_modules/react-native-linear-gradient/android/build.gradle",
    "fix5": "sed -i '' 's\/targetSdkVersion 23\/targetSdkVersion 25\/' ./node_modules/react-native-linear-gradient/android/build.gradle",
    "fix6": "sed -i '' 's\/#import <RCTAnimation\\/RCTValueAnimatedNode.h>\/#import \"RCTValueAnimatedNode.h\"\/' ./node_modules/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h",
    "postinstall": "npm run fix0 && npm run fix1 && npm run fix2 && npm run fix3 && npm run fix4 && npm run fix5 && npm run fix6",
```