### PR TITLE
Add support for permission request rationale

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -60,7 +60,7 @@ class ReactNativePermissions {
 	}
 
 
-	request(permission, rationale) {
+	request(permission, { rationale }) {
 		const androidPermission = RNPTypes[permission]
   	if (!androidPermission) return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on Android`);
 

--- a/index.android.js
+++ b/index.android.js
@@ -60,12 +60,12 @@ class ReactNativePermissions {
 	}
 
 
-	request(permission) {
+	request(permission, rationale) {
 		const androidPermission = RNPTypes[permission]
   	if (!androidPermission) return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on Android`);
 
 
-		return RNPermissions.request(androidPermission)
+		return RNPermissions.request(androidPermission, rationale)
 			.then(res => {
 				return setDidAskOnce(permission)
 					.then(() => RESULTS[res])

--- a/index.ios.js
+++ b/index.ios.js
@@ -43,7 +43,15 @@ class ReactNativePermissions {
 		return RNPermissions.getPermissionStatus(permission, type);
 	}
 
-	request(permission, type) {
+	request(permission, options) {
+		let type = null;
+		if (typeof options === 'string' || options instanceof Array) {
+			console.warn('[react-native-permissions] : You are using a deprecated version of request(). You should use an object as second parameter. Please check the documentation for more information : https://github.com/yonahforst/react-native-permissions');
+			type = options;
+		} else {
+			type = options.type;
+		}
+
 		if (!RNPTypes.includes(permission)) {
 			return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on iOS`);
 		}


### PR DESCRIPTION
According to https://facebook.github.io/react-native/docs/permissionsandroid.html#request

We should be able to add a rationale for permission request.

Tested on Android API 23