### PR TITLE
Add READ_SMS and RECEIVE_SMS permissions

### DIFF
--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
     <uses-permission android:name="android.permission.READ_CALENDAR"/>
-
+    <uses-permission android:name="android.permission.READ_SMS"/>
+    <uses-permission android:name="android.permission.RECEIVE_SMS"/>
 
     <application
       android:name=".MainApplication"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The current supported permissions are:
 - Push Notifications *(iOS only)*
 - Background Refresh *(iOS only)*
 - Speech Recognition *(iOS only)*
+- Read/Receive SMS *(Android only)*
 
 
 | Version | React Native Support |
@@ -120,6 +121,8 @@ Promises resolve into one of these statuses
 |`backgroundRefresh`| ✔️ | ❌ |
 |`speechRecognition`| ✔️ | ❌ |
 |`storage`| ❌️ | ✔ |
+|`readSms`| ❌️ | ✔ |
+|`receiveSms`| ❌️ | ✔ |
 
 ### Methods
 | Method Name | Arguments | Notes

--- a/index.android.js
+++ b/index.android.js
@@ -13,7 +13,7 @@ const RNPTypes = {
 	storage: RNPermissions.PERMISSIONS.READ_EXTERNAL_STORAGE,
 	photo: RNPermissions.PERMISSIONS.READ_EXTERNAL_STORAGE,
 	readSms: RNPermissions.PERMISSIONS.READ_SMS,
-	receiveSms: RNPermissions.PERMISSIONS.READ_SMS,
+	receiveSms: RNPermissions.PERMISSIONS.RECEIVE_SMS,
 }
 
 const RESULTS = {

--- a/index.android.js
+++ b/index.android.js
@@ -12,6 +12,8 @@ const RNPTypes = {
 	event: RNPermissions.PERMISSIONS.READ_CALENDAR,
 	storage: RNPermissions.PERMISSIONS.READ_EXTERNAL_STORAGE,
 	photo: RNPermissions.PERMISSIONS.READ_EXTERNAL_STORAGE,
+	readSms: RNPermissions.PERMISSIONS.READ_SMS,
+	receiveSms: RNPermissions.PERMISSIONS.READ_SMS,
 }
 
 const RESULTS = {
@@ -41,7 +43,7 @@ class ReactNativePermissions {
 	check(permission) {
 		const androidPermission = RNPTypes[permission]
   	if (!androidPermission) return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on Android`);
-		
+
 		const shouldShowRationale = ReactNative.NativeModules.PermissionsAndroid.shouldShowRequestPermissionRationale;
 
 		return RNPermissions.check(androidPermission)


### PR DESCRIPTION
Closes #107 

To be honest I'm not sure of what's the difference between `READ` and `RECEIVE`  in this case, because when I tested with the example app, granting one of those automatically granted the other as well. I'd guess that `RECEIVE` is for listening to incoming SMS and `READ` for reading from existing SMS. I bet it's probably safe to break it down to a single `sms` case, so if you're willing to change this just let me know :D

Edit: Tested on 6.0.0 emulator and 6.0.1 physical device, both working