### PR TITLE
Fix errors that occur when building for iOS with RN 0.48.0-rc.0.

### DIFF
--- a/ReactNativePermissions.h
+++ b/ReactNativePermissions.h
@@ -6,10 +6,12 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if __has_include("RCTBridgeModule.h")
-  #import "RCTBridgeModule.h"
+#if __has_include(<React/RCTBridge.h>)
+  #import <React/RCTBridge.h>
+#elif __has_include("RCTBridge.h")
+  #import "RCTBridge.h"
 #else
-  #import <React/RCTBridgeModule.h>
+  #import "React/RCTBridge.h"
 #endif
 
 @interface ReactNativePermissions : NSObject <RCTBridgeModule>

--- a/ReactNativePermissions.m
+++ b/ReactNativePermissions.m
@@ -10,15 +10,6 @@
 
 #import "ReactNativePermissions.h"
 
-#if __has_include(<React/RCTBridge.h>)
-  #import <React/RCTBridge.h>
-#elif __has_include("RCTBridge.h")
-  #import "RCTBridge.h"
-#else
-  #import "React/RCTBridge.h"
-#endif
-
-
 #if __has_include("RCTConvert.h")
   #import "RCTConvert.h"
 #else


### PR DESCRIPTION
I noticed that errors occur when building for iOS with RN 0.48.0-rc.0 like below:
```
node_modules/react-native/React/Base/RCTBridgeModule.h:54:16: Redefinition of 'RCTMethodInfo'
node_modules/react-native/React/Base/RCTBridgeModule.h:58:3: Typedef redefinition with different types ('struct (anonymous struct at RCTBridgeModule.h:54:16)' vs 'struct RCTMethodInfo')
```

Because RCTBridgeModule.h is included in RCTBridge.h, I think that RCTBridgeModule.h is not needed to be included separately.