### PR TITLE
Switch from using rnpm to react-native cli in setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ npm install --save react-native-permissions
 react-native link
 ````
 
-### Or manualy linking
+### Or manually linking
 
 #### iOS
 * Run open node_modules/react-native-permissions

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The current supported permissions are:
 ## General Usage
 ```
 npm install --save react-native-permissions
-rnpm link
+react-native link
 ```
 
 Add permissions to manifest for android and info.plist for ios (xcode >=8). See notes below for more details.
@@ -179,7 +179,7 @@ You can request write access to any of these types by also including the appropr
 
 ````
 npm install --save react-native-permissions
-rnpm link
+react-native link
 ````
 
 ### Or manualy linking


### PR DESCRIPTION
* react-native CLI is the modern way to go and should be encouraged. (rnpm is deprecated)
* also fix minor typo