### PR TITLE
fix checkMultiple handling of permissions with type on iOS

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -39,6 +39,8 @@ class ReactNativePermissions {
   	if (!RNPTypes.includes(permission)) {
 			return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on iOS`);
 		}
+				
+		type = type || DEFAULTS[permission]
 		
 		return RNPermissions.getPermissionStatus(permission, type);
 	}
@@ -58,7 +60,7 @@ class ReactNativePermissions {
 	}
 
 	checkMultiple(permissions) {
-		return Promise.all(permissions.map(this.check.bind(this)))
+		return Promise.all(permissions.map(permission => this.check(permission)))
 			.then(res => res.reduce((pre, cur, i) => {
 				var name = permissions[i]
 				pre[name] = cur

--- a/index.ios.js
+++ b/index.ios.js
@@ -39,8 +39,6 @@ class ReactNativePermissions {
   	if (!RNPTypes.includes(permission)) {
 			return Promise.reject(`ReactNativePermissions: ${permission} is not a valid permission type on iOS`);
 		}
-				
-		type = type || DEFAULTS[permission]
 		
 		return RNPermissions.getPermissionStatus(permission, type);
 	}


### PR DESCRIPTION
Related to this:
https://github.com/yonahforst/react-native-permissions/issues/133

This is just a bug fix.
If we want to support passing 'types' to `checkMultiple` I think a different pr is required (and discussed since it can be implemented a few ways).