### PR TITLE
Fix importing React/RCTBridgeModule.h

### DIFF
--- a/ReactNativePermissions.h
+++ b/ReactNativePermissions.h
@@ -6,10 +6,10 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if __has_include("RCTBridgeModule.h")
-  #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
   #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
 #endif
 
 @interface ReactNativePermissions : NSObject <RCTBridgeModule>


### PR DESCRIPTION
If somewhere in code already was import by file name only:

```
  #import "RCTBridgeModule.h"
```

Next import will fail if you try to import by another method:

```
  #import <React/RCTBridgeModule.h>
```

Becouse paths are different, but import by filename will work every time.