### PR TITLE
Fix RN 0.48+ warning about requiresMainQueueSetup

### DIFF
--- a/ReactNativePermissions.m
+++ b/ReactNativePermissions.m
@@ -57,6 +57,11 @@
 RCT_EXPORT_MODULE();
 @synthesize bridge = _bridge;
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 #pragma mark Initialization
 
 - (instancetype)init


### PR DESCRIPTION
Fixes the warning

```
Module ReactNativePermissions requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
```