### PR TITLE
Add `NSPhotoLibraryAddUsageDescription` for Info.plist doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ So before submitting your app to the App Store, make sure that in your
 <string>Some description</string>
 <key>NSLocationWhenInUseUsageDescription</key>
 <string>Some description</string>
+<key>NSPhotoLibraryAddUsageDescription</key>
+<string>Some description</string>
 <key>NSPhotoLibraryUsageDescription</key>
 <string>Some description</string>
 <key>NSSpeechRecognitionUsageDescription</key>


### PR DESCRIPTION
I recently got issue in some version of iOS (apparently 10?) with this key missing.
Not sure why I needed that but as it feel redundant with the key below, but this avoid some crashes I found with sentry :)