### PR TITLE
Cocoapods: Fix issue <React/RCTConvert.h> not found

### DIFF
--- a/ReactNativePermissions.podspec
+++ b/ReactNativePermissions.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
   s.preserve_paths         = 'LICENSE', 'package.json'
   s.source_files           = '**/*.{h,m}'
   s.exclude_files          = 'example/**/*'
+  s.dependency               'React'
 end


### PR DESCRIPTION
See #191.
Fixes issue <React/RCTConvert.h> by adding the missing dependency.