### PR TITLE
Fix of bugs related to permission location type "always/whenInUse"

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ user how the app uses this data. **Even if you don't use them**.
 So before submitting your app to the App Store, make sure that in your
 `Info.plist` you have the following keys:
 
-````xml
+```xml
 <key>NSBluetoothPeripheralUsageDescription</key>
 <string>Some description</string>
 <key>NSCalendarsUsageDescription</key>
@@ -244,6 +244,7 @@ So before submitting your app to the App Store, make sure that in your
 <key>NSMotionUsageDescription</key>
 <string>Some description</string>
 ```
+
 This is required because during the phase of processing in the App Store
 submission, the system detects that you app contains code to request the
 permission `X` but don't have the `UsageDescription` key and then it rejects the
@@ -279,7 +280,7 @@ Permissions.request('camera', {
 }).then(response => {
   this.setState({ cameraPermission: response })
 })
-````
+```
 
 * Permissions are automatically accepted for **targetSdkVersion < 23** but you
   can still use `check()` to check if the user has disabled them from Settings.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ react-native link react-native-permissions
    folder ➜ `Add Files to <...>`
 2. Go to `node_modules` ➜ `react-native-permissions` ➜ select
    `ReactNativePermissions.xcodeproj`
-3. Add `libReactNativePermissions.a` to `Build Phases` -> `Link Binary With
-   Libraries`
+3. Add `libReactNativePermissions.a` to `Build Phases` -> `Link Binary With Libraries`
 
 ## Using
 
@@ -139,7 +138,7 @@ Promises resolve into one of these statuses:
 | Return value   | Notes                                                                                                                                                                                                                                                                  |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `authorized`   | User has authorized this permission                                                                                                                                                                                                                                    |
-| `denied`       | User has denied this permission at least once. On iOS this means that the user will not be prompted again. Android users can be prompted multiple times until they select 'Never ask me again'                                                                          |
+| `denied`       | User has denied this permission at least once. On iOS this means that the user will not be prompted again. Android users can be prompted multiple times until they select 'Never ask me again'                                                                         |
 | `restricted`   | **iOS** - this means user is not able to grant this permission, either because it's not supported by the device or because it has been blocked by parental controls. **Android** - this means that the user has selected 'Never ask me again' while denying permission |
 | `undetermined` | User has not yet been prompted with a permission dialog                                                                                                                                                                                                                |
 
@@ -212,8 +211,7 @@ Permissions.request('notification', { type: ['alert', 'badge'] }).then(
   will request. Open Xcode ➜ `Info.plist` ➜ Add a key (starting with "Privacy -
   ...") with your kit specific permission.
 
-Example: If you need Contacts permission you have to add the key `Privacy -
-Contacts Usage Description`.
+Example: If you need Contacts permission you have to add the key `Privacy - Contacts Usage Description`.
 
 <img width="338" alt="3cde3b44-7ffd-11e6-918b-63888e33f983" src="https://cloud.githubusercontent.com/assets/1440796/18713019/271be540-8011-11e6-87fb-c3828c172dfc.png">
 
@@ -226,7 +224,7 @@ user how the app uses this data. **Even if you don't use them**.
 So before submitting your app to the App Store, make sure that in your
 `Info.plist` you have the following keys:
 
-```xml
+````xml
 <key>NSBluetoothPeripheralUsageDescription</key>
 <string>Some description</string>
 <key>NSCalendarsUsageDescription</key>
@@ -281,7 +279,7 @@ Permissions.request('camera', {
 }).then(response => {
   this.setState({ cameraPermission: response })
 })
-```
+````
 
 * Permissions are automatically accepted for **targetSdkVersion < 23** but you
   can still use `check()` to check if the user has disabled them from Settings.

--- a/example/App.js
+++ b/example/App.js
@@ -9,6 +9,7 @@ import {
   Alert,
   AppState,
   Platform,
+  ScrollView,
 } from 'react-native'
 
 import Permissions from 'react-native-permissions'
@@ -94,42 +95,44 @@ export default class App extends Component {
   render() {
     return (
       <View style={styles.container}>
-        {this.state.types.map(p => (
-          <TouchableHighlight
-            style={[styles.button, styles[this.state.status[p]]]}
-            key={p}
-            onPress={() => this._requestPermission(p)}
-          >
-            <View>
-              <Text style={styles.text}>
-                {Platform.OS == 'ios' && p == 'location'
-                  ? `location ${this.state.isAlways ? 'always' : 'whenInUse'}`
-                  : p}
-              </Text>
-              <Text style={styles.subtext}>{this.state.status[p]}</Text>
-            </View>
-          </TouchableHighlight>
-        ))}
-        <View style={styles.footer}>
-          <TouchableHighlight
-            style={styles['footer_' + Platform.OS]}
-            onPress={this._onLocationSwitchChange}
-          >
-            <Text style={styles.text}>Toggle location type</Text>
-          </TouchableHighlight>
-
-          {this.state.canOpenSettings && (
-            <TouchableHighlight onPress={this._openSettings}>
-              <Text style={styles.text}>Open settings</Text>
+        <ScrollView>
+          {this.state.types.map(p => (
+            <TouchableHighlight
+              style={[styles.button, styles[this.state.status[p]]]}
+              key={p}
+              onPress={() => this._requestPermission(p)}
+            >
+              <View>
+                <Text style={styles.text}>
+                  {Platform.OS == 'ios' && p == 'location'
+                    ? `location ${this.state.isAlways ? 'always' : 'whenInUse'}`
+                    : p}
+                </Text>
+                <Text style={styles.subtext}>{this.state.status[p]}</Text>
+              </View>
             </TouchableHighlight>
-          )}
-        </View>
+          ))}
+          <View style={styles.footer}>
+            <TouchableHighlight
+              style={styles['footer_' + Platform.OS]}
+              onPress={this._onLocationSwitchChange}
+            >
+              <Text style={styles.text}>Toggle location type</Text>
+            </TouchableHighlight>
 
-        <Text style={styles['footer_' + Platform.OS]}>
-          Note: microphone permissions may not work on iOS simulator. Also,
-          toggling permissions from the settings menu may cause the app to
-          crash. This is normal on iOS. Google "ios crash permission change"
-        </Text>
+            {this.state.canOpenSettings && (
+              <TouchableHighlight onPress={this._openSettings}>
+                <Text style={styles.text}>Open settings</Text>
+              </TouchableHighlight>
+            )}
+          </View>
+
+          <Text style={styles['footer_' + Platform.OS]}>
+            Note: microphone permissions may not work on iOS simulator. Also,
+            toggling permissions from the settings menu may cause the app to
+            crash. This is normal on iOS. Google "ios crash permission change"
+          </Text>
+        </ScrollView>
       </View>
     )
   }

--- a/example/ios/Example/Info.plist
+++ b/example/ios/Example/Info.plist
@@ -49,6 +49,8 @@
 	<string>test</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>test</string>
+  <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+  <string>test</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>6.0</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -76,7 +76,7 @@ NSString *const EscalatedServiceRequested = @"RNP_ESCALATED_PERMISSION_REQUESTED
             
             [self.locationManager requestAlwaysAuthorization];
             
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 4 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
                 if(self.completionHandler){
                     self.completionHandler(RNPStatusDenied);
                     self.completionHandler = nil;

--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -12,7 +12,7 @@
 @interface RNPLocation() <CLLocationManagerDelegate>
 @property (strong, nonatomic) CLLocationManager* locationManager;
 @property (strong, nonatomic) NSString * lastTypeRequested;
-@property (strong, nonatomic ) NSNumber * initallAuthCallback;
+@property (strong, nonatomic ) NSNumber * initalAuthCallback;
 @property (copy) void (^completionHandler)(NSString *);
 @end
 
@@ -46,7 +46,7 @@
     if (self.locationManager == nil) {
         self.locationManager = [[CLLocationManager alloc] init];
         self.locationManager.delegate = self;
-        self.initallAuthCallback = [NSNumber numberWithBool:YES];
+        self.initalAuthCallback = [NSNumber numberWithBool:YES];
     }
     return self;
 }
@@ -73,8 +73,8 @@
     // This works good in an native app, but since we operating with a callback we needs to skip frist time
     // didChangeAuthorizationStatus is called.
     // https://stackoverflow.com/questions/30106341/swift-locationmanager-didchangeauthorizationstatus-always-called/30107511
-    if([self.initallAuthCallback boolValue] == YES){
-        self.initallAuthCallback = [NSNumber numberWithBool:NO];
+    if([self.initalAuthCallback boolValue] == YES){
+        self.initalAuthCallback = [NSNumber numberWithBool:NO];
         return;
     }
     

--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -9,7 +9,6 @@
 #import "RNPLocation.h"
 #import <CoreLocation/CoreLocation.h>
 
-
 @interface RNPLocation() <CLLocationManagerDelegate>
 @property (strong, nonatomic) CLLocationManager* locationManager;
 @property (strong, nonatomic) NSString * lastTypeRequested;
@@ -22,8 +21,7 @@
 + (NSString *)getStatusForType:(NSString *)type
 {
     int status = [CLLocationManager authorizationStatus];
-    NSString * rnpStatus =  [RNPLocation convert:status for:type];
-    NSLog(@"getStatusForType(type=%@)=> %@",type,rnpStatus);
+    NSString * rnpStatus =  [RNPLocation convert:status for:type];    
     return rnpStatus;
 }
 
@@ -53,20 +51,16 @@
     return self;
 }
 
-
 - (void)request:(NSString*)type completionHandler:(void (^)(NSString *))completionHandler
 {
-    NSString *status = [RNPLocation getStatusForType:type];
-    NSLog(@"Requesting location. Current status s:%@", status);
+    NSString *status = [RNPLocation getStatusForType:type];    
     if (status != RNPStatusAuthorized) {
         self.lastTypeRequested = type;
         self.completionHandler = completionHandler;
       
-        if ([type isEqualToString:@"always"]) {
-            NSLog(@"Requestiong requestAlwaysAuthorization");
+        if ([type isEqualToString:@"always"]) {            
             [self.locationManager requestAlwaysAuthorization];
-        } else {
-            NSLog(@"Requestiong requestWhenInUseAuthorization");
+        } else {            
             [self.locationManager requestWhenInUseAuthorization];
         }
     } else {
@@ -74,9 +68,7 @@
     }
 }
 
--(void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-
-    NSLog(@"didChangeAuthorizationStatus");
+-(void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {    
     // Function is called once just after the CLLocationManager is created.
     // This works good in an native app, but since we operating with a callback we needs to skip frist time
     // didChangeAuthorizationStatus is called.
@@ -86,12 +78,8 @@
         return;
     }
     
-    NSLog(@"didChangeAuthorizationStatus: status=%@;  lastRequested:%@ ",
-          [RNPLocation convert:status for:self.lastTypeRequested], self.lastTypeRequested );
-
     if (self.completionHandler) {
-        NSString * rnpStatus = [RNPLocation convert:status for:self.lastTypeRequested];
-        NSLog(@"DONE - callback with status: %@",rnpStatus);
+        NSString * rnpStatus = [RNPLocation convert:status for:self.lastTypeRequested];    
         self.completionHandler(rnpStatus);
         self.completionHandler = nil;
     }

--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -17,6 +17,8 @@
 @end
 
 @implementation RNPLocation
+NSString *const EscalatedServiceRequested = @"RNP_ESCALATED_PERMISSION_REQUESTED";
+
 
 + (NSString *)getStatusForType:(NSString *)type
 {
@@ -49,7 +51,7 @@
         // Detect if user already has asked for escalated permission
         // kCLAuthorizationStatusAuthorizedWhenInUse -> kCLAuthorizationStatusAuthorizedAlways
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        NSString * hasEscalated = [defaults stringForKey:@"escalated"];
+        NSString * hasEscalated = [defaults stringForKey:EscalatedServiceRequested];
         self.escelatedRightsRequested = [NSNumber numberWithBool: hasEscalated == nil ? NO : YES];
 
     }
@@ -68,7 +70,7 @@
         if ([type isEqualToString:@"always"]) {
             // Save the info about the 'always use' request we are about to make
             NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-            [defaults setObject:@"YES" forKey:@"escalated"];
+            [defaults setObject:@"YES" forKey:EscalatedServiceRequested];
             [defaults synchronize];
             self.escelatedRightsRequested = [NSNumber numberWithBool:YES];
             

--- a/lib/permissions.android.js
+++ b/lib/permissions.android.js
@@ -45,9 +45,7 @@ class ReactNativePermissions {
   check = (permission: string, options?: CheckOptions): Promise<Status> => {
     if (!permissionTypes[permission]) {
       const error = new Error(
-        `ReactNativePermissions: ${
-          permission
-        } is not a valid permission type on Android`,
+        `ReactNativePermissions: ${permission} is not a valid permission type on Android`,
       )
 
       return Promise.reject(error)
@@ -75,9 +73,7 @@ class ReactNativePermissions {
   request = (permission: string, options?: RequestOptions): Promise<Status> => {
     if (!permissionTypes[permission]) {
       const error = new Error(
-        `ReactNativePermissions: ${
-          permission
-        } is not a valid permission type on Android`,
+        `ReactNativePermissions: ${permission} is not a valid permission type on Android`,
       )
 
       return Promise.reject(error)

--- a/lib/permissions.ios.js
+++ b/lib/permissions.ios.js
@@ -21,7 +21,7 @@ const permissionTypes = [
   'backgroundRefresh',
   'speechRecognition',
   'mediaLibrary',
-  'motion'
+  'motion',
 ]
 
 const DEFAULTS = {
@@ -40,9 +40,7 @@ class ReactNativePermissions {
   check = (permission: string, options?: CheckOptions): Promise<Status> => {
     if (!permissionTypes.includes(permission)) {
       const error = new Error(
-        `ReactNativePermissions: ${
-          permission
-        } is not a valid permission type on iOS`,
+        `ReactNativePermissions: ${permission} is not a valid permission type on iOS`,
       )
 
       return Promise.reject(error)
@@ -65,9 +63,7 @@ class ReactNativePermissions {
   request = (permission: string, options?: RequestOptions): Promise<Status> => {
     if (!permissionTypes.includes(permission)) {
       const error = new Error(
-        `ReactNativePermissions: ${
-          permission
-        } is not a valid permission type on iOS`,
+        `ReactNativePermissions: ${permission} is not a valid permission type on iOS`,
       )
 
       return Promise.reject(error)


### PR DESCRIPTION
This PR fixes multiple bugs I encountered related to location permission and type _always_.

My initial problem was that after first requesting permission _whenInUse_ I did not manage to escalate the permission to _always_, even though this should be possible.


This was caused by the _request()_ method starting with a call to:
```javascript
NSString *status = [RNPLocation getStatusForType:nil];
```
Since we already had _kCLAuthorizationStatusAuthorizedWhenInUse_ rights from the first permission request, we would never enter:
```javascript
NSString *status = [RNPLocation getStatusForType:nil];
if (status == RNPStatusUndetermined) {
  self.completionHandler = completionHandler;
```
So the request for permission type _always_ would never be triggered.


So what I did:


* Since we never will get _RNPStatusUndetermined_ when we try to ecalate permission from _whenInUse_ to _always_, I changed to logic so that the only status that causes us not to ask for permission is _RNPStatusAuthorized_.


* Next I added a init() method to setup or _locationManger_.  According to my observations AND https://stackoverflow.com/questions/30106341/swift-locationmanager-didchangeauthorizationstatus-always-called/30107511  the delegate is called once when the _CLLocationManager_ is initialized. 
This caused all kinds of wierd behavior when trying to escalate permission, since the _CLLocationManager_ was initialized for each request, every permission request caused two _didChangeAuthorizationStatus callbacks.
In the case of trying to _escalate_ permission we would already have the permission _kCLAuthorizationStatusAuthorizedWhenInUse_ from the first request, causing us to enter: 
    ```javascript
    (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus: CLAuthorizationStatus)status {
      if (status != kCLAuthorizationStatusNotDetermined) {
    ````
    which then would trigger the callback to RN. This would happen just after initializing the _locationManger_ in the request method, before we actually had requested the _escalated_ permission. 
This would then return _Denied_ to the client.
By holding a variable who checks if its initial callback, we could remove the check for _kCLAuthorizationStatusNotDetermined_ in the delegate method and always treat it properly.

* Fixed #168 by keeping a copy of type in _lastTypeRequested_. By doing this we know the requested type, and may use it in _didChangeAuthorizationStatus_.

* Using the status returned in the _didChangeAuthorizationStatus_ instead of fetching it from _CLLocationManager_. This seems to remove the need for the _dispatch_after(dispatch_time)_ hack.

* Updated the example project to work with permission type _always_.













