### PR TITLE
Bring back openSettings on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,34 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.1.+'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 24
+    buildToolsVersion "25.0.2"
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 24
+        versionCode 1
+        versionName "1.0"
+    }
+    lintOptions {
+        abortOnError false
+    }
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile 'com.facebook.react:react-native:+'
+}

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.joshblour.reactnativepermissions">
+</manifest>

--- a/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java
+++ b/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsModule.java
@@ -1,0 +1,53 @@
+package com.joshblour.reactnativepermissions;
+
+import android.Manifest;
+import android.content.Intent;
+import android.net.Uri;
+import android.provider.Settings;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.NotificationManagerCompat;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.content.PermissionChecker;
+
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.PromiseImpl;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.modules.permissions.PermissionsModule;
+
+import java.util.Locale;
+
+public class ReactNativePermissionsModule extends ReactContextBaseJavaModule {
+  private final ReactApplicationContext reactContext;
+
+  public ReactNativePermissionsModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    this.reactContext = reactContext;
+  }
+
+  @Override
+  public String getName() {
+    return "ReactNativePermissions";
+  }
+
+  @ReactMethod
+  public void canOpenSettings(Promise promise) {
+    promise.resolve(true);
+  }
+
+  @ReactMethod
+  public void openSettings() {
+    final Intent i = new Intent();
+    i.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+    i.addCategory(Intent.CATEGORY_DEFAULT);
+    i.setData(Uri.parse("package:" + this.reactContext.getPackageName()));
+    i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    i.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+    i.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS);
+    this.reactContext.startActivity(i);
+  }
+}

--- a/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsPackage.java
+++ b/android/src/main/java/com/joshblour/reactnativepermissions/ReactNativePermissionsPackage.java
@@ -1,0 +1,27 @@
+package com.joshblour.reactnativepermissions;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+import com.facebook.react.bridge.JavaScriptModule;
+
+public class ReactNativePermissionsPackage implements ReactPackage {
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+      return Arrays.<NativeModule>asList(new ReactNativePermissionsModule(reactContext));
+    }
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+      return Collections.emptyList();
+    }
+}

--- a/lib/permissions.android.js
+++ b/lib/permissions.android.js
@@ -2,6 +2,8 @@
 
 import { AsyncStorage, NativeModules, PermissionsAndroid } from 'react-native'
 
+const Android = NativeModules.ReactNativePermissions;
+
 type Status = 'authorized' | 'denied' | 'restricted' | 'undetermined'
 type Rationale = { title: string, message: string }
 type CheckOptions = string | { type: string }
@@ -35,10 +37,9 @@ const getDidAskOnce = (permission: string) =>
   AsyncStorage.getItem(STORAGE_KEY + permission).then(item => !!item)
 
 class ReactNativePermissions {
-  canOpenSettings: () => Promise<boolean> = () => Promise.resolve(false)
+  canOpenSettings: () => Promise<boolean> = Android.canOpenSettings;
 
-  openSettings: () => Promise<*> = () =>
-    Promise.reject(new Error("'openSettings' is deprecated on android"))
+  openSettings: () => Promise<*> = Android.openSettings;
 
   getTypes: () => Array<string> = () => Object.keys(permissionTypes)
 


### PR DESCRIPTION
I know there are other library could do that. But for API completeness I think it should be included.

Another option is to remove the API for ios altogether.