### PR TITLE
[NOT READY] Selective permissions

### DIFF
--- a/ios/Permissions/RNPAudioVideo.h
+++ b/ios/Permissions/RNPAudioVideo.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE || defined RNP_TYPE_CAMERA
+#if defined RNP_TYPE_MICROPHONE || defined RNP_TYPE_CAMERA
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>

--- a/ios/Permissions/RNPAudioVideo.h
+++ b/ios/Permissions/RNPAudioVideo.h
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE || defined RNP_TYPE_CAMERA
+
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
@@ -15,3 +17,5 @@
 + (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler;
 
 @end
+
+#endif

--- a/ios/Permissions/RNPAudioVideo.h
+++ b/ios/Permissions/RNPAudioVideo.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#import <AVFoundation/AVFoundation.h>
 
 @interface RNPAudioVideo : NSObject
 

--- a/ios/Permissions/RNPAudioVideo.m
+++ b/ios/Permissions/RNPAudioVideo.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE || defined RNP_TYPE_CAMERA
+#if defined RNP_TYPE_MICROPHONE || defined RNP_TYPE_CAMERA
 
 #import "RNPAudioVideo.h"
 #import "RCTConvert+RNPStatus.h"

--- a/ios/Permissions/RNPAudioVideo.m
+++ b/ios/Permissions/RNPAudioVideo.m
@@ -7,14 +7,13 @@
 //
 
 #import "RNPAudioVideo.h"
-
-#import <AVFoundation/AVFoundation.h>
+#import "RCTConvert+RNPStatus.h"
 
 @implementation RNPAudioVideo
 
 + (NSString *)getStatus:(NSString *)type
 {
-    int status = [AVCaptureDevice authorizationStatusForMediaType:[self typeFromString:type]];
+    int status = [AVCaptureDevice authorizationStatusForMediaType:type];
     switch (status) {
         case AVAuthorizationStatusAuthorized:
             return RNPStatusAuthorized;
@@ -29,20 +28,12 @@
 
 + (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler
 {
-    [AVCaptureDevice requestAccessForMediaType:[self typeFromString:type]
+    [AVCaptureDevice requestAccessForMediaType:type
                              completionHandler:^(BOOL granted) {
                                  dispatch_async(dispatch_get_main_queue(), ^{
                                      completionHandler([RNPAudioVideo getStatus:type]);
                                  });
                              }];
-}
-
-+ (NSString *)typeFromString:(NSString *)string {
-    if ([string isEqualToString:@"audio"]) {
-        return AVMediaTypeAudio;
-    } else {
-        return AVMediaTypeVideo;
-    }
 }
 
 @end

--- a/ios/Permissions/RNPAudioVideo.m
+++ b/ios/Permissions/RNPAudioVideo.m
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE || defined RNP_TYPE_CAMERA
+
 #import "RNPAudioVideo.h"
 #import "RCTConvert+RNPStatus.h"
 
@@ -37,3 +39,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPBackgroundRefresh.h
+++ b/ios/Permissions/RNPBackgroundRefresh.h
@@ -6,11 +6,15 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BACKGROUND_REFRESH
+
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
 
-@interface RNPBackgroundRefresh : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
+@interface RNPBackgroundRefresh : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPBackgroundRefresh.h
+++ b/ios/Permissions/RNPBackgroundRefresh.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BACKGROUND_REFRESH
+#ifdef RNP_TYPE_BACKGROUND_REFRESH
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"

--- a/ios/Permissions/RNPBackgroundRefresh.m
+++ b/ios/Permissions/RNPBackgroundRefresh.m
@@ -6,11 +6,13 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BACKGROUND_REFRESH
+
 #import "RNPBackgroundRefresh.h"
 
 @implementation RNPBackgroundRefresh
 
-+(NSString *)getStatus
++(NSString *)getStatus:(id)json
 {
     int status = [[UIApplication sharedApplication] backgroundRefreshStatus];
     switch (status) {
@@ -25,4 +27,12 @@
     }
 
 }
+
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
+{
+    
+}
+
 @end
+
+#endif

--- a/ios/Permissions/RNPBackgroundRefresh.m
+++ b/ios/Permissions/RNPBackgroundRefresh.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BACKGROUND_REFRESH
+#ifdef RNP_TYPE_BACKGROUND_REFRESH
 
 #import "RNPBackgroundRefresh.h"
 

--- a/ios/Permissions/RNPBluetooth.h
+++ b/ios/Permissions/RNPBluetooth.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BLUETOOTH
+#ifdef RNP_TYPE_BLUETOOTH
 
 #import <Foundation/Foundation.h>
 #import <CoreBluetooth/CoreBluetooth.h>

--- a/ios/Permissions/RNPBluetooth.h
+++ b/ios/Permissions/RNPBluetooth.h
@@ -6,12 +6,15 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BLUETOOTH
+
 #import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#import <CoreBluetooth/CoreBluetooth.h>
 
-@interface RNPBluetooth : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
-- (void)request:(void (^)(NSString *))completionHandler;
+@interface RNPBluetooth : NSObject <CBPeripheralManagerDelegate, RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPBluetooth.m
+++ b/ios/Permissions/RNPBluetooth.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BLUETOOTH
+#ifdef RNP_TYPE_BLUETOOTH
 
 #import "RNPBluetooth.h"
 #import "RCTConvert+RNPStatus.h"

--- a/ios/Permissions/RNPCamera.h
+++ b/ios/Permissions/RNPCamera.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CAMERA
+#ifdef RNP_TYPE_CAMERA
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPCamera.h
+++ b/ios/Permissions/RNPCamera.h
@@ -1,0 +1,17 @@
+//
+//  RNPCameraVideo.h
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CAMERA
+
+#import "RNPPermission.h"
+
+@interface RNPCamera : NSObject <RNPermission>
+
+@end
+
+#endif

--- a/ios/Permissions/RNPCamera.h
+++ b/ios/Permissions/RNPCamera.h
@@ -10,7 +10,7 @@
 
 #import "RNPPermission.h"
 
-@interface RNPCamera : NSObject <RNPermission>
+@interface RNPCamera : NSObject <RNPPermission>
 
 @end
 

--- a/ios/Permissions/RNPCamera.m
+++ b/ios/Permissions/RNPCamera.m
@@ -1,0 +1,28 @@
+//
+//  RNPCameraVideo.m
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CAMERA
+
+#import "RNPCamera.h"
+#import "RNPAudioVideo.h"
+
+@implementation RNPCamera
+
++ (NSString *)getStatus:(id)json
+{
+    return [RNPAudioVideo getStatus:AVMediaTypeVideo];
+}
+
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
+{
+    [RNPAudioVideo request:AVMediaTypeVideo completionHandler:completionHandler];
+}
+
+@end
+
+#endif

--- a/ios/Permissions/RNPCamera.m
+++ b/ios/Permissions/RNPCamera.m
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CAMERA
+#ifdef RNP_TYPE_CAMERA
 
 #import "RNPCamera.h"
 #import "RNPAudioVideo.h"

--- a/ios/Permissions/RNPContacts.h
+++ b/ios/Permissions/RNPContacts.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CONTACTS
+#ifdef RNP_TYPE_CONTACTS
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPContacts.h
+++ b/ios/Permissions/RNPContacts.h
@@ -6,12 +6,12 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CONTACTS
 
-@interface RNPContacts : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
-+ (void)request:(void (^)(NSString *))completionHandler;
+@interface RNPContacts : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPContacts.m
+++ b/ios/Permissions/RNPContacts.m
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CONTACTS
+
 #import "RNPContacts.h"
 #import <AddressBook/AddressBook.h>
 
@@ -15,7 +17,7 @@
 
 @implementation RNPContacts
 
-+ (NSString *)getStatus
++ (NSString *)getStatus:(id)json
 {
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_9_0
     int status = [CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts];
@@ -44,11 +46,11 @@
 #endif
 }
 
-+ (void)request:(void (^)(NSString *))completionHandler
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
 {
     void (^handler)(BOOL, NSError * _Nullable) =  ^(BOOL granted, NSError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler([self.class getStatus]);
+            completionHandler([self.class getStatus:nil]);
         });
     };
     
@@ -67,3 +69,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPContacts.m
+++ b/ios/Permissions/RNPContacts.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CONTACTS
+#ifdef RNP_TYPE_CONTACTS
 
 #import "RNPContacts.h"
 #import <AddressBook/AddressBook.h>

--- a/ios/Permissions/RNPEvent.h
+++ b/ios/Permissions/RNPEvent.h
@@ -6,12 +6,12 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT
 
-@interface RNPEvent : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus:(NSString *)type;
-+ (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler;
+@interface RNPEvent : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPEvent.h
+++ b/ios/Permissions/RNPEvent.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT
+#ifdef RNP_TYPE_EVENT
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPEvent.m
+++ b/ios/Permissions/RNPEvent.m
@@ -6,43 +6,23 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT
+
 #import "RNPEvent.h"
-#import <EventKit/EventKit.h>
+#import "RNPEventStore.h"
 
 @implementation RNPEvent
 
-+ (NSString *)getStatus:(NSString *)type
++ (NSString *)getStatus:(id)json
 {
-    int status = [EKEventStore authorizationStatusForEntityType:[self typeFromString:type]];
-
-    switch (status) {
-        case EKAuthorizationStatusAuthorized:
-            return RNPStatusAuthorized;
-        case EKAuthorizationStatusDenied:
-            return RNPStatusDenied;
-        case EKAuthorizationStatusRestricted:
-            return RNPStatusRestricted;
-        default:
-            return RNPStatusUndetermined;
-    }
+    return [RNPEventStore getStatus:EKEntityTypeEvent];
 }
 
-+ (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
 {
-    EKEventStore *aStore = [[EKEventStore alloc] init];
-    [aStore requestAccessToEntityType:[self typeFromString:type] completion:^(BOOL granted, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler([self getStatus:type]);
-        });
-    }];
-}
-
-+(EKEntityType)typeFromString:(NSString *)string {
-    if ([string isEqualToString:@"reminder"]) {
-        return EKEntityTypeReminder;
-    } else {
-        return EKEntityTypeEvent;
-    }
+    [RNPEventStore request:EKEntityTypeEvent completionHandler:completionHandler];
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPEvent.m
+++ b/ios/Permissions/RNPEvent.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT
+#ifdef RNP_TYPE_EVENT
 
 #import "RNPEvent.h"
 #import "RNPEventStore.h"

--- a/ios/Permissions/RNPEventStore.h
+++ b/ios/Permissions/RNPEventStore.h
@@ -1,0 +1,18 @@
+//
+//  RNPEventStore.h
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <EventKit/EventKit.h>
+
+@interface RNPEventStore : NSObject
+
++ (NSString *)getStatus:(EKEntityType)type;
++ (void)request:(EKEntityType)type completionHandler:(void (^)(NSString *))completionHandler;
+
+@end
+

--- a/ios/Permissions/RNPEventStore.h
+++ b/ios/Permissions/RNPEventStore.h
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT || defined RNP_TYPE_REMINDER
+
 #import <Foundation/Foundation.h>
 #import <EventKit/EventKit.h>
 
@@ -16,3 +18,4 @@
 
 @end
 
+#endif

--- a/ios/Permissions/RNPEventStore.h
+++ b/ios/Permissions/RNPEventStore.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT || defined RNP_TYPE_REMINDER
+#if defined RNP_TYPE_EVENT || defined RNP_TYPE_REMINDER
 
 #import <Foundation/Foundation.h>
 #import <EventKit/EventKit.h>

--- a/ios/Permissions/RNPEventStore.m
+++ b/ios/Permissions/RNPEventStore.m
@@ -1,0 +1,40 @@
+//
+//  RNPEventStore.m
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#import "RNPEventStore.h"
+#import "RCTConvert+RNPStatus.h"
+
+@implementation RNPEventStore
+
++ (NSString *)getStatus:(EKEntityType)type
+{
+    int status = [EKEventStore authorizationStatusForEntityType:type];
+    
+    switch (status) {
+        case EKAuthorizationStatusAuthorized:
+            return RNPStatusAuthorized;
+        case EKAuthorizationStatusDenied:
+            return RNPStatusDenied;
+        case EKAuthorizationStatusRestricted:
+            return RNPStatusRestricted;
+        default:
+            return RNPStatusUndetermined;
+    }
+}
+
++ (void)request:(EKEntityType)type completionHandler:(void (^)(NSString *))completionHandler
+{
+    EKEventStore *aStore = [[EKEventStore alloc] init];
+    [aStore requestAccessToEntityType:type completion:^(BOOL granted, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler([self getStatus:type]);
+        });
+    }];
+}
+
+@end

--- a/ios/Permissions/RNPEventStore.m
+++ b/ios/Permissions/RNPEventStore.m
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT || defined RNP_TYPE_REMINDER
+
 #import "RNPEventStore.h"
 #import "RCTConvert+RNPStatus.h"
 
@@ -38,3 +40,5 @@
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPEventStore.m
+++ b/ios/Permissions/RNPEventStore.m
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT || defined RNP_TYPE_REMINDER
+#if defined RNP_TYPE_EVENT || defined RNP_TYPE_REMINDER
 
 #import "RNPEventStore.h"
 #import "RCTConvert+RNPStatus.h"

--- a/ios/Permissions/RNPLocation.h
+++ b/ios/Permissions/RNPLocation.h
@@ -6,12 +6,13 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_LOCATION
 
-@interface RNPLocation : NSObject
+#import "RNPPermission.h"
+#import <CoreLocation/CoreLocation.h>
 
-+ (NSString *)getStatusForType:(NSString *)type;
-- (void)request:(NSString *)type completionHandler:(void (^)(NSString *))completionHandler;
+@interface RNPLocation : NSObject <CLLocationManagerDelegate, RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPLocation.h
+++ b/ios/Permissions/RNPLocation.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_LOCATION
+#ifdef RNP_TYPE_LOCATION
 
 #import "RNPPermission.h"
 #import <CoreLocation/CoreLocation.h>

--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_LOCATION
+#ifdef RNP_TYPE_LOCATION
 
 #import "RNPLocation.h"
 #import "RCTConvert+RNPStatus.h"

--- a/ios/Permissions/RNPMediaLibrary.h
+++ b/ios/Permissions/RNPMediaLibrary.h
@@ -6,12 +6,12 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MEDIA_LIBRARY
 
-@interface RNPMediaLibrary : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
-+ (void)request:(void (^)(NSString *))completionHandler;
+@interface RNPMediaLibrary : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPMediaLibrary.h
+++ b/ios/Permissions/RNPMediaLibrary.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MEDIA_LIBRARY
+#ifdef RNP_TYPE_MEDIA_LIBRARY
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPMediaLibrary.m
+++ b/ios/Permissions/RNPMediaLibrary.m
@@ -6,12 +6,14 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MEDIA_LIBRARY
+
 #import "RNPMediaLibrary.h"
 #import <MediaPlayer/MediaPlayer.h>
 
 @implementation RNPMediaLibrary
 
-+ (NSString *)getStatus
++ (NSString *)getStatus:(id)json
 {
     int status = [MPMediaLibrary authorizationStatus];
     switch (status) {
@@ -26,11 +28,11 @@
     }
 }
 
-+ (void)request:(void (^)(NSString *))completionHandler
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
 {
     void (^handler)(void) =  ^(void) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler([self.class getStatus]);
+            completionHandler([self.class getStatus:nil]);
         });
     };
     
@@ -39,3 +41,5 @@
     }];
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPMediaLibrary.m
+++ b/ios/Permissions/RNPMediaLibrary.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MEDIA_LIBRARY
+#ifdef RNP_TYPE_MEDIA_LIBRARY
 
 #import "RNPMediaLibrary.h"
 #import <MediaPlayer/MediaPlayer.h>

--- a/ios/Permissions/RNPMicrophone.h
+++ b/ios/Permissions/RNPMicrophone.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE
+#ifdef RNP_TYPE_MICROPHONE
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPMicrophone.h
+++ b/ios/Permissions/RNPMicrophone.h
@@ -1,0 +1,17 @@
+//
+//  RNPMicrophone.h
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE
+
+#import "RNPPermission.h"
+
+@interface RNPMicrophone : NSObject <RNPPermission>
+
+@end
+
+#endif

--- a/ios/Permissions/RNPMicrophone.m
+++ b/ios/Permissions/RNPMicrophone.m
@@ -1,0 +1,28 @@
+//
+//  RNPCameraAudio.m
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE
+
+#import "RNPMicrophone.h"
+#import "RNPAudioVideo.h"
+
+@implementation RNPMicrophone
+
++ (NSString *)getStatus:(id)json
+{
+    return [RNPAudioVideo getStatus:AVMediaTypeAudio];
+}
+
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
+{
+    [RNPAudioVideo request:AVMediaTypeAudio completionHandler:completionHandler];
+}
+
+@end
+
+#endif

--- a/ios/Permissions/RNPMicrophone.m
+++ b/ios/Permissions/RNPMicrophone.m
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE
+#ifdef RNP_TYPE_MICROPHONE
 
 #import "RNPMicrophone.h"
 #import "RNPAudioVideo.h"

--- a/ios/Permissions/RNPMotion.h
+++ b/ios/Permissions/RNPMotion.h
@@ -3,12 +3,12 @@
 //  ReactNativePermissions
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MOTION
 
-@interface RNPMotion : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
-+ (void)request:(void (^)(NSString *))completionHandler;
+@interface RNPMotion : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPMotion.h
+++ b/ios/Permissions/RNPMotion.h
@@ -3,7 +3,7 @@
 //  ReactNativePermissions
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MOTION
+#ifdef RNP_TYPE_MOTION
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPMotion.m
+++ b/ios/Permissions/RNPMotion.m
@@ -3,12 +3,14 @@
 //  ReactNativePermissions
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MOTION
+
 #import "RNPMotion.h"
 #import <CoreMotion/CoreMotion.h>
 
 @implementation RNPMotion
 
-+ (NSString *)getStatus
++ (NSString *)getStatus:(id)json
 {
     if (![CMMotionActivityManager isActivityAvailable]) {
         return RNPStatusRestricted;
@@ -34,9 +36,9 @@
     }
 }
 
-+ (void)request:(void (^)(NSString *))completionHandler
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
 {
-    __block NSString *status = [RNPMotion getStatus];
+    __block NSString *status = [self.class getStatus:nil];
     
     if ([status isEqual: RNPStatusUndetermined]) {
         __block CMMotionActivityManager *activityManager = [[CMMotionActivityManager alloc] init];
@@ -60,3 +62,5 @@
     }
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPMotion.m
+++ b/ios/Permissions/RNPMotion.m
@@ -3,7 +3,7 @@
 //  ReactNativePermissions
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MOTION
+#ifdef RNP_TYPE_MOTION
 
 #import "RNPMotion.h"
 #import <CoreMotion/CoreMotion.h>

--- a/ios/Permissions/RNPNotification.h
+++ b/ios/Permissions/RNPNotification.h
@@ -6,12 +6,14 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_NOTIFICATION
+
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"
+#import "RNPPermission.h"
 
-@interface RNPNotification : NSObject
-
-+ (NSString *)getStatus;
-- (void)request:(UIUserNotificationType)types completionHandler:(void (^)(NSString*))completionHandler;
+@interface RNPNotification : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPNotification.h
+++ b/ios/Permissions/RNPNotification.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_NOTIFICATION
+#ifdef RNP_TYPE_NOTIFICATION
 
 #import <Foundation/Foundation.h>
 #import "RCTConvert+RNPStatus.h"

--- a/ios/Permissions/RNPNotification.m
+++ b/ios/Permissions/RNPNotification.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_NOTIFICATION
+#ifdef RNP_TYPE_NOTIFICATION
 
 #import "RNPNotification.h"
 

--- a/ios/Permissions/RNPNotification.m
+++ b/ios/Permissions/RNPNotification.m
@@ -69,7 +69,7 @@ static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
     if (status == RNPStatusUndetermined) {
         sharedMgr.completionHandler = completionHandler;
 
-        [[NSNotificationCenter defaultCenter] addObserver:self
+        [[NSNotificationCenter defaultCenter] addObserver:sharedMgr
                                                  selector:@selector(applicationDidBecomeActive)
                                                      name:UIApplicationDidBecomeActiveNotification
                                                    object:nil];

--- a/ios/Permissions/RNPNotification.m
+++ b/ios/Permissions/RNPNotification.m
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_NOTIFICATION
+
 #import "RNPNotification.h"
 
 static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
@@ -16,7 +18,16 @@ static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
 
 @implementation RNPNotification
 
-+ (NSString *)getStatus
++ (RNPNotification *)sharedManager {
+    static RNPNotification *sharedManager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedManager = [[self alloc] init];
+    });
+    return sharedManager;
+}
+
++ (NSString *)getStatus:(id)json
 {
     BOOL didAskForPermission = [[NSUserDefaults standardUserDefaults] boolForKey:RNPDidAskForNotification];
     BOOL isEnabled = [[[UIApplication sharedApplication] currentUserNotificationSettings] types] != UIUserNotificationTypeNone;
@@ -29,12 +40,34 @@ static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
 }
 
 
-- (void)request:(UIUserNotificationType)types completionHandler:(void (^)(NSString*))completionHandler
++ (UIUserNotificationType)typesFromJSON:(id)json
 {
-    NSString *status = [self.class getStatus];
+    NSArray *typeStrings = [RCTConvert NSArray:json];
+    
+    UIUserNotificationType types = UIUserNotificationTypeNone;
+
+    if ([typeStrings containsObject:@"alert"])
+        types = types | UIUserNotificationTypeAlert;
+    
+    if ([typeStrings containsObject:@"badge"])
+        types = types | UIUserNotificationTypeBadge;
+    
+    if ([typeStrings containsObject:@"sound"])
+        types = types | UIUserNotificationTypeSound;
+    
+    return types;
+}
+
+
++ (void)request:(void (^)(NSString*))completionHandler json:(id)json
+{
+    NSString *status = [self getStatus:nil];
+    UIUserNotificationType types = [self typesFromJSON:json];
+    
+    RNPNotification *sharedMgr = [self sharedManager];
 
     if (status == RNPStatusUndetermined) {
-        self.completionHandler = completionHandler;
+        sharedMgr.completionHandler = completionHandler;
 
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(applicationDidBecomeActive)
@@ -61,10 +94,12 @@ static NSString* RNPDidAskForNotification = @"RNPDidAskForNotification";
     if (self.completionHandler) {
         //for some reason, checking permission right away returns denied. need to wait a tiny bit
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-            self.completionHandler([self.class getStatus]);
+            self.completionHandler([self.class getStatus:nil]);
             self.completionHandler = nil;
         });
     }
 }
 
 @end
+
+#endif

--- a/ios/Permissions/RNPPermission.h
+++ b/ios/Permissions/RNPPermission.h
@@ -1,0 +1,22 @@
+//
+//  RNPPermission.h
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#ifndef RNPPermission_h
+#define RNPPermission_h
+
+#import <Foundation/Foundation.h>
+#import "RCTConvert+RNPStatus.h"
+
+@protocol RNPPermission
+
++ (NSString *)getStatus:(id)json;
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json;
+
+@end
+
+#endif /* RNPPermission_h */

--- a/ios/Permissions/RNPPermissionClasses.h
+++ b/ios/Permissions/RNPPermissionClasses.h
@@ -1,0 +1,21 @@
+//
+//  RNPPermissionClasses.h
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 10.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCTConvert+RNPStatus.h"
+#import "RNPPermission.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNPPermissionClasses : NSObject
+
++ (Class<RNPPermission>)classForType:(RNPType)type;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Permissions/RNPPermissionClasses.m
+++ b/ios/Permissions/RNPPermissionClasses.m
@@ -14,43 +14,43 @@
 + (NSDictionary *)permissionClasses
 {
     return @{
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_LOCATION
+#ifdef RNP_TYPE_LOCATION
              @(RNPTypeLocation) : @"RNPLocation",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CAMERA
+#ifdef RNP_TYPE_CAMERA
              @(RNPTypeCamera) : @"RNPCamera",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE
+#ifdef RNP_TYPE_MICROPHONE
              @(RNPTypeMicrophone) : @"RNPMicrophone",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_PHOTO
+#ifdef RNP_TYPE_PHOTO
              @(RNPTypePhoto) : @"RNPPhoto",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CONTACTS
+#ifdef RNP_TYPE_CONTACTS
              @(RNPTypeContacts) : @"RNPContacts",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT
+#ifdef RNP_TYPE_EVENT
              @(RNPTypeEvent) : @"RNPEvent",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_REMINDER
+#ifdef RNP_TYPE_REMINDER
              @(RNPTypeReminder) : @"RNPReminder",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BLUETOOTH
+#ifdef RNP_TYPE_BLUETOOTH
              @(RNPTypeBluetooth) : @"RNPBluetooth",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_NOTIFICATION
+#ifdef RNP_TYPE_NOTIFICATION
              @(RNPTypeNotification) : @"RNPNotification",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BACKGROUND_REFRESH
+#ifdef RNP_TYPE_BACKGROUND_REFRESH
              @(RNPTypeBackgroundRefresh) : @"RNPBackgroundRefresh",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_SPEECH_RECOGNITION
+#ifdef RNP_TYPE_SPEECH_RECOGNITION
              @(RNPTypeSpeechRecognition) : @"RNPSpeechRecognition",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MEDIA_LIBRARY
+#ifdef RNP_TYPE_MEDIA_LIBRARY
              @(RNPTypeMediaLibrary) : @"RNPMediaLibrary",
 #endif
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MOTION
+#ifdef RNP_TYPE_MOTION
              @(RNPTypeMotion) : @"RNPMotion",
 #endif
              };

--- a/ios/Permissions/RNPPermissionClasses.m
+++ b/ios/Permissions/RNPPermissionClasses.m
@@ -1,0 +1,66 @@
+//
+//  RNPPermissionClasses.m
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 10.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#import "RNPPermissionClasses.h"
+
+@implementation RNPPermissionClasses
+
+
++ (NSDictionary *)permissionClasses
+{
+    return @{
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_LOCATION
+             @(RNPTypeLocation) : @"RNPLocation",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CAMERA
+             @(RNPTypeCamera) : @"RNPCamera",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MICROPHONE
+             @(RNPTypeMicrophone) : @"RNPMicrophone",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_PHOTO
+             @(RNPTypePhoto) : @"RNPPhoto",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_CONTACTS
+             @(RNPTypeContacts) : @"RNPContacts",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_EVENT
+             @(RNPTypeEvent) : @"RNPEvent",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_REMINDER
+             @(RNPTypeReminder) : @"RNPReminder",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BLUETOOTH
+             @(RNPTypeBluetooth) : @"RNPBluetooth",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_NOTIFICATION
+             @(RNPTypeNotification) : @"RNPNotification",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_BACKGROUND_REFRESH
+             @(RNPTypeBackgroundRefresh) : @"RNPBackgroundRefresh",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_SPEECH_RECOGNITION
+             @(RNPTypeSpeechRecognition) : @"RNPSpeechRecognition",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MEDIA_LIBRARY
+             @(RNPTypeMediaLibrary) : @"RNPMediaLibrary",
+#endif
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_MOTION
+             @(RNPTypeMotion) : @"RNPMotion",
+#endif
+             };
+}
+
++ (Class<RNPPermission>)classForType:(RNPType)type
+{
+    NSString *className = [[self permissionClasses] objectForKey:@(type)];
+    
+    return NSClassFromString(className);
+}
+
+@end

--- a/ios/Permissions/RNPPhoto.h
+++ b/ios/Permissions/RNPPhoto.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_PHOTO
+#ifdef RNP_TYPE_PHOTO
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPPhoto.h
+++ b/ios/Permissions/RNPPhoto.h
@@ -6,12 +6,12 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_PHOTO
 
-@interface RNPPhoto : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
-+ (void)request:(void (^)(NSString *))completionHandler;
+@interface RNPPhoto : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPPhoto.m
+++ b/ios/Permissions/RNPPhoto.m
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_PHOTO
+#ifdef RNP_TYPE_PHOTO
 
 #import "RNPPhoto.h"
 #import <AssetsLibrary/AssetsLibrary.h>

--- a/ios/Permissions/RNPPhoto.m
+++ b/ios/Permissions/RNPPhoto.m
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_PHOTO
+
 #import "RNPPhoto.h"
 #import <AssetsLibrary/AssetsLibrary.h>
 
@@ -13,7 +15,7 @@
 
 @implementation RNPPhoto
 
-+ (NSString *)getStatus
++ (NSString *)getStatus:(id)json
 {
     int status = [PHPhotoLibrary authorizationStatus];
     switch (status) {
@@ -28,11 +30,11 @@
     }
 }
 
-+ (void)request:(void (^)(NSString *))completionHandler
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
 {
     void (^handler)(void) =  ^(void) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler([self.class getStatus]);
+            completionHandler([self.class getStatus:nil]);
         });
     };
 
@@ -41,3 +43,5 @@
     }];
 }
 @end
+
+#endif

--- a/ios/Permissions/RNPReminder.h
+++ b/ios/Permissions/RNPReminder.h
@@ -1,0 +1,17 @@
+//
+//  RNPReminder.h
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_REMINDER
+
+#import "RNPPermission.h"
+
+@interface RNPReminder : NSObject <RNPPermission>
+
+@end
+
+#endif

--- a/ios/Permissions/RNPReminder.h
+++ b/ios/Permissions/RNPReminder.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_REMINDER
+#ifdef RNP_TYPE_REMINDER
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPReminder.m
+++ b/ios/Permissions/RNPReminder.m
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_REMINDER
+#ifdef RNP_TYPE_REMINDER
 
 #import "RNPReminder.h"
 #import "RNPEventStore.h"

--- a/ios/Permissions/RNPReminder.m
+++ b/ios/Permissions/RNPReminder.m
@@ -1,0 +1,28 @@
+//
+//  RNPReminder.m
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_REMINDER
+
+#import "RNPReminder.h"
+#import "RNPEventStore.h"
+
+@implementation RNPReminder
+
++ (NSString *)getStatus:(id)json
+{
+    return [RNPEventStore getStatus:EKEntityTypeReminder];
+}
+
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
+{
+    [RNPEventStore request:EKEntityTypeReminder completionHandler:completionHandler];
+}
+
+@end
+
+#endif

--- a/ios/Permissions/RNPSpeechRecognition.h
+++ b/ios/Permissions/RNPSpeechRecognition.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_SPEECH_RECOGNITION
+#ifdef RNP_TYPE_SPEECH_RECOGNITION
 
 #import "RNPPermission.h"
 

--- a/ios/Permissions/RNPSpeechRecognition.h
+++ b/ios/Permissions/RNPSpeechRecognition.h
@@ -6,12 +6,12 @@
 //  Copyright © 2017 Yonah Forst. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "RCTConvert+RNPStatus.h"
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_SPEECH_RECOGNITION
 
-@interface RNPSpeechRecognition : NSObject
+#import "RNPPermission.h"
 
-+ (NSString *)getStatus;
-+ (void)request:(void (^)(NSString *))completionHandler;
+@interface RNPSpeechRecognition : NSObject <RNPPermission>
 
 @end
+
+#endif

--- a/ios/Permissions/RNPSpeechRecognition.m
+++ b/ios/Permissions/RNPSpeechRecognition.m
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Yonah Forst. All rights reserved.
 //
 
-#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_SPEECH_RECOGNITION
+#ifdef RNP_TYPE_SPEECH_RECOGNITION
 
 #import "RNPSpeechRecognition.h"
 #import <Speech/Speech.h>

--- a/ios/Permissions/RNPSpeechRecognition.m
+++ b/ios/Permissions/RNPSpeechRecognition.m
@@ -6,14 +6,15 @@
 //  Copyright © 2017 Yonah Forst. All rights reserved.
 //
 
+#if !defined RNP_PERMISSIONS_SELECTIVE || defined RNP_TYPE_SPEECH_RECOGNITION
+
 #import "RNPSpeechRecognition.h"
 #import <Speech/Speech.h>
 
 @implementation RNPSpeechRecognition
 
-+ (NSString *)getStatus
++ (NSString *)getStatus:(id)json
 {
-
   int status = [SFSpeechRecognizer authorizationStatus];
 
   switch (status) {
@@ -28,11 +29,11 @@
   }
 }
 
-+ (void)request:(void (^)(NSString *))completionHandler
++ (void)request:(void (^)(NSString *))completionHandler json:(id)json
 {
     void (^handler)(void) =  ^(void) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler([self.class getStatus]);
+            completionHandler([self.class getStatus:nil]);
         });
     };
 
@@ -42,3 +43,5 @@
 }
 
 @end
+
+#endif

--- a/ios/RNPConfig.xcconfig
+++ b/ios/RNPConfig.xcconfig
@@ -1,0 +1,26 @@
+//
+//  RNPConfig.xcconfig
+//  ReactNativePermissions
+//
+//  Created by Artur Chrusciel on 09.11.18.
+//  Copyright © 2018 Yonah Forst. All rights reserved.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// RNPPermissions.xcconfig contains preprocessor directives to enable selective
+// permission types and there is no need to provide usage descriptions in Info.plist
+
+// File must be placed in <PROJECT_DIR>/ios/RNPPermissions.xcconfig
+
+// Example RNPPermissions.xcconfig content:
+
+// RNP_SELECTIVE = RNP_PERMISSIONS_SELECTIVE
+// RNP_PERMISSION_TYPES = RNP_TYPE_LOCATION RNP_TYPE_NOTIFICATION RNP_TYPE_BLUETOOTH RNP_TYPE_MEDIA_LIBRARY
+
+// Full list of permission types preprocessor directives in
+// Permissions/RNPPermissionClasses.m
+
+
+#include? "../../../ios/RNPPermissions.xcconfig"

--- a/ios/RNPConfig.xcconfig
+++ b/ios/RNPConfig.xcconfig
@@ -10,13 +10,12 @@
 // https://help.apple.com/xcode/#/dev745c5c974
 
 // RNPPermissions.xcconfig contains preprocessor directives to enable selective
-// permission types and there is no need to provide usage descriptions in Info.plist
+// permission types and then there is no need to provide usage descriptions in Info.plist
 
 // File must be placed in <PROJECT_DIR>/ios/RNPPermissions.xcconfig
 
 // Example RNPPermissions.xcconfig content:
 
-// RNP_SELECTIVE = RNP_PERMISSIONS_SELECTIVE
 // RNP_PERMISSION_TYPES = RNP_TYPE_LOCATION RNP_TYPE_NOTIFICATION RNP_TYPE_BLUETOOTH RNP_TYPE_MEDIA_LIBRARY
 
 // Full list of permission types preprocessor directives in

--- a/ios/ReactNativePermissions.m
+++ b/ios/ReactNativePermissions.m
@@ -37,8 +37,10 @@
 #import "RNPLocation.h"
 #import "RNPBluetooth.h"
 #import "RNPNotification.h"
-#import "RNPAudioVideo.h"
+#import "RNPMicrophone.h"
+#import "RNPCamera.h"
 #import "RNPEvent.h"
+#import "RNPReminder.h"
 #import "RNPPhoto.h"
 #import "RNPContacts.h"
 #import "RNPBackgroundRefresh.h"
@@ -46,12 +48,15 @@
 #import "RNPMediaLibrary.h"
 #import "RNPMotion.h"
 
+#import "RNPPermissionClasses.h"
 
-@interface ReactNativePermissions()
-@property (strong, nonatomic) RNPLocation *locationMgr;
-@property (strong, nonatomic) RNPNotification *notificationMgr;
-@property (strong, nonatomic) RNPBluetooth *bluetoothMgr;
-@end
+#define TYPE_NAME(type) #type
+#define REJECT(type) \
+    reject( \
+           @"RNPTypeNotSupported", \
+           [NSString stringWithFormat:@"Type %s not supported", TYPE_NAME(type)], \
+           nil);
+
 
 @implementation ReactNativePermissions
 
@@ -91,7 +96,6 @@ RCT_REMAP_METHOD(canOpenSettings, canOpenSettings:(RCTPromiseResolveBlock)resolv
 RCT_EXPORT_METHOD(openSettings:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     if (@(UIApplicationOpenSettingsURLString != nil)) {
-
         NSNotificationCenter * __weak center = [NSNotificationCenter defaultCenter];
         id __block token = [center addObserverForName:UIApplicationDidBecomeActiveNotification
                                                object:nil
@@ -109,139 +113,24 @@ RCT_EXPORT_METHOD(openSettings:(RCTPromiseResolveBlock)resolve rejecter:(RCTProm
 
 RCT_REMAP_METHOD(getPermissionStatus, getPermissionStatus:(RNPType)type json:(id)json resolve:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSString *status;
+    NSString *status = [[RNPPermissionClasses classForType:type] getStatus:json];
 
-    switch (type) {
-
-        case RNPTypeLocation: {
-            NSString *locationPermissionType = [RCTConvert NSString:json];
-            status = [RNPLocation getStatusForType:locationPermissionType];
-            break;
-        }
-        case RNPTypeCamera:
-            status = [RNPAudioVideo getStatus:@"video"];
-            break;
-        case RNPTypeMicrophone:
-            status = [RNPAudioVideo getStatus:@"audio"];
-            break;
-        case RNPTypePhoto:
-            status = [RNPPhoto getStatus];
-            break;
-        case RNPTypeContacts:
-            status = [RNPContacts getStatus];
-            break;
-        case RNPTypeEvent:
-            status = [RNPEvent getStatus:@"event"];
-            break;
-        case RNPTypeReminder:
-            status = [RNPEvent getStatus:@"reminder"];
-            break;
-        case RNPTypeBluetooth:
-            status = [RNPBluetooth getStatus];
-            break;
-        case RNPTypeNotification:
-            status = [RNPNotification getStatus];
-            break;
-        case RNPTypeBackgroundRefresh:
-            status = [RNPBackgroundRefresh getStatus];
-            break;
-        case RNPTypeSpeechRecognition:
-            status = [RNPSpeechRecognition getStatus];
-            break;
-        case RNPTypeMediaLibrary:
-            status = [RNPMediaLibrary getStatus];
-            break;
-        case RNPTypeMotion:
-            status = [RNPMotion getStatus];
-            break;
-        default:
-            break;
+    if (status) {
+        resolve(status);
+    } else {
+        REJECT(type)
     }
-
-    resolve(status);
 }
 
 RCT_REMAP_METHOD(requestPermission, permissionType:(RNPType)type json:(id)json resolve:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    NSString *status;
+    Class<RNPPermission> c = [RNPPermissionClasses classForType:type];
 
-    switch (type) {
-        case RNPTypeLocation:
-            return [self requestLocation:json resolve:resolve];
-        case RNPTypeCamera:
-            return [RNPAudioVideo request:@"video" completionHandler:resolve];
-        case RNPTypeMicrophone:
-            return [RNPAudioVideo request:@"audio" completionHandler:resolve];
-        case RNPTypePhoto:
-            return [RNPPhoto request:resolve];
-        case RNPTypeContacts:
-            return [RNPContacts request:resolve];
-        case RNPTypeEvent:
-            return [RNPEvent request:@"event" completionHandler:resolve];
-        case RNPTypeReminder:
-            return [RNPEvent request:@"reminder" completionHandler:resolve];
-        case RNPTypeBluetooth:
-            return [self requestBluetooth:resolve];
-        case RNPTypeNotification:
-            return [self requestNotification:json resolve:resolve];
-        case RNPTypeSpeechRecognition:
-            return [RNPSpeechRecognition request:resolve];
-        case RNPTypeMediaLibrary:
-            return [RNPMediaLibrary request:resolve];
-        case RNPTypeMotion:
-            return [RNPMotion request:resolve];
-        default:
-            break;
+    if (c) {
+        [c request:resolve json:json];
+    } else {
+        REJECT(type)
     }
-
-
 }
-
-- (void) requestLocation:(id)json resolve:(RCTPromiseResolveBlock)resolve
-{
-    if (self.locationMgr == nil) {
-        self.locationMgr = [[RNPLocation alloc] init];
-    }
-
-    NSString *type = [RCTConvert NSString:json];
-
-    [self.locationMgr request:type completionHandler:resolve];
-}
-
-- (void) requestNotification:(id)json resolve:(RCTPromiseResolveBlock)resolve
-{
-    NSArray *typeStrings = [RCTConvert NSArray:json];
-
-    UIUserNotificationType types;
-    if ([typeStrings containsObject:@"alert"])
-        types = types | UIUserNotificationTypeAlert;
-
-    if ([typeStrings containsObject:@"badge"])
-        types = types | UIUserNotificationTypeBadge;
-
-    if ([typeStrings containsObject:@"sound"])
-        types = types | UIUserNotificationTypeSound;
-
-
-    if (self.notificationMgr == nil) {
-        self.notificationMgr = [[RNPNotification alloc] init];
-    }
-
-    [self.notificationMgr request:types completionHandler:resolve];
-
-}
-
-
-- (void) requestBluetooth:(RCTPromiseResolveBlock)resolve
-{
-    if (self.bluetoothMgr == nil) {
-        self.bluetoothMgr = [[RNPBluetooth alloc] init];
-    }
-
-    [self.bluetoothMgr request:resolve];
-}
-
-
-
 
 @end

--- a/ios/ReactNativePermissions.m
+++ b/ios/ReactNativePermissions.m
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Yonah Forst. All rights reserved.
 //
 
-@import Contacts;
-
 #import "ReactNativePermissions.h"
 
 #if __has_include(<React/RCTBridge.h>)

--- a/ios/ReactNativePermissions.xcodeproj/project.pbxproj
+++ b/ios/ReactNativePermissions.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		};
 		9D23B3591C767B80008B4819 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -352,6 +353,7 @@
 		};
 		9D23B35A1C767B80008B4819 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
 				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "";
 				HEADER_SEARCH_PATHS = (

--- a/ios/ReactNativePermissions.xcodeproj/project.pbxproj
+++ b/ios/ReactNativePermissions.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		669582131FE441A8008596CD /* RNPAudioVideo.m in Sources */ = {isa = PBXBuildFile; fileRef = 669582071FE441A7008596CD /* RNPAudioVideo.m */; };
 		669582141FE441A8008596CD /* RNPContacts.m in Sources */ = {isa = PBXBuildFile; fileRef = 669582081FE441A8008596CD /* RNPContacts.m */; };
 		669582151FE441A8008596CD /* RNPEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 6695820A1FE441A8008596CD /* RNPEvent.m */; };
+		8C1F8BBA21963A0C00165235 /* RNPEventStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C1F8BB921963A0C00165235 /* RNPEventStore.m */; };
+		8C1F8BBD21963CE700165235 /* RNPReminder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C1F8BBC21963CE700165235 /* RNPReminder.m */; };
+		8C1F8BC021963DFA00165235 /* RNPMicrophone.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C1F8BBF21963DFA00165235 /* RNPMicrophone.m */; };
+		8C1F8BC32196406A00165235 /* RNPCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C1F8BC22196406A00165235 /* RNPCamera.m */; };
+		8C1F8BC82196573700165235 /* RNPPermissionClasses.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C1F8BC72196573700165235 /* RNPPermissionClasses.m */; };
 		D0AD62322000657000D89898 /* RNPMotion.m in Sources */ = {isa = PBXBuildFile; fileRef = D0AD62312000657000D89898 /* RNPMotion.m */; };
 /* End PBXBuildFile section */
 
@@ -61,6 +66,18 @@
 		6695820A1FE441A8008596CD /* RNPEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPEvent.m; sourceTree = "<group>"; };
 		6695820B1FE441A8008596CD /* RNPSpeechRecognition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPSpeechRecognition.h; sourceTree = "<group>"; };
 		6695820C1FE441A8008596CD /* RNPNotification.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPNotification.h; sourceTree = "<group>"; };
+		8C1F8BB72196231700165235 /* RNPConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = RNPConfig.xcconfig; sourceTree = "<group>"; };
+		8C1F8BB821963A0C00165235 /* RNPEventStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPEventStore.h; sourceTree = "<group>"; };
+		8C1F8BB921963A0C00165235 /* RNPEventStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNPEventStore.m; sourceTree = "<group>"; };
+		8C1F8BBB21963CE700165235 /* RNPReminder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPReminder.h; sourceTree = "<group>"; };
+		8C1F8BBC21963CE700165235 /* RNPReminder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNPReminder.m; sourceTree = "<group>"; };
+		8C1F8BBE21963DFA00165235 /* RNPMicrophone.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPMicrophone.h; sourceTree = "<group>"; };
+		8C1F8BBF21963DFA00165235 /* RNPMicrophone.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNPMicrophone.m; sourceTree = "<group>"; };
+		8C1F8BC12196406A00165235 /* RNPCamera.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPCamera.h; sourceTree = "<group>"; };
+		8C1F8BC22196406A00165235 /* RNPCamera.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNPCamera.m; sourceTree = "<group>"; };
+		8C1F8BC42196429100165235 /* RNPPermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPPermission.h; sourceTree = "<group>"; };
+		8C1F8BC62196573700165235 /* RNPPermissionClasses.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNPPermissionClasses.h; sourceTree = "<group>"; };
+		8C1F8BC72196573700165235 /* RNPPermissionClasses.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNPPermissionClasses.m; sourceTree = "<group>"; };
 		9D23B34F1C767B80008B4819 /* libReactNativePermissions.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libReactNativePermissions.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0AD62302000656F00D89898 /* RNPMotion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNPMotion.h; sourceTree = "<group>"; };
 		D0AD62312000657000D89898 /* RNPMotion.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNPMotion.m; sourceTree = "<group>"; };
@@ -111,6 +128,17 @@
 				669582031FE441A7008596CD /* RNPPhoto.m */,
 				6695820B1FE441A8008596CD /* RNPSpeechRecognition.h */,
 				669581FD1FE441A7008596CD /* RNPSpeechRecognition.m */,
+				8C1F8BB821963A0C00165235 /* RNPEventStore.h */,
+				8C1F8BB921963A0C00165235 /* RNPEventStore.m */,
+				8C1F8BBB21963CE700165235 /* RNPReminder.h */,
+				8C1F8BBC21963CE700165235 /* RNPReminder.m */,
+				8C1F8BBE21963DFA00165235 /* RNPMicrophone.h */,
+				8C1F8BBF21963DFA00165235 /* RNPMicrophone.m */,
+				8C1F8BC12196406A00165235 /* RNPCamera.h */,
+				8C1F8BC22196406A00165235 /* RNPCamera.m */,
+				8C1F8BC42196429100165235 /* RNPPermission.h */,
+				8C1F8BC62196573700165235 /* RNPPermissionClasses.h */,
+				8C1F8BC72196573700165235 /* RNPPermissionClasses.m */,
 			);
 			path = Permissions;
 			sourceTree = "<group>";
@@ -118,6 +146,7 @@
 		9D23B3461C767B80008B4819 = {
 			isa = PBXGroup;
 			children = (
+				8C1F8BB72196231700165235 /* RNPConfig.xcconfig */,
 				669581FA1FE44191008596CD /* Permissions */,
 				669581F61FE4416B008596CD /* RCTConvert+RNPStatus.h */,
 				669581F41FE4416B008596CD /* RCTConvert+RNPStatus.m */,
@@ -193,17 +222,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				669582111FE441A8008596CD /* RNPNotification.m in Sources */,
+				8C1F8BC32196406A00165235 /* RNPCamera.m in Sources */,
 				488FE29C200BC8A100E05AB0 /* RNPMediaLibrary.m in Sources */,
 				669582151FE441A8008596CD /* RNPEvent.m in Sources */,
 				669582101FE441A8008596CD /* RNPBackgroundRefresh.m in Sources */,
 				669581F71FE4416B008596CD /* RCTConvert+RNPStatus.m in Sources */,
 				6695820E1FE441A8008596CD /* RNPLocation.m in Sources */,
+				8C1F8BC021963DFA00165235 /* RNPMicrophone.m in Sources */,
+				8C1F8BC82196573700165235 /* RNPPermissionClasses.m in Sources */,
 				6695820F1FE441A8008596CD /* RNPBluetooth.m in Sources */,
 				669582141FE441A8008596CD /* RNPContacts.m in Sources */,
 				6695820D1FE441A8008596CD /* RNPSpeechRecognition.m in Sources */,
 				669582131FE441A8008596CD /* RNPAudioVideo.m in Sources */,
 				D0AD62322000657000D89898 /* RNPMotion.m in Sources */,
+				8C1F8BBA21963A0C00165235 /* RNPEventStore.m in Sources */,
 				669581F81FE4416B008596CD /* ReactNativePermissions.m in Sources */,
+				8C1F8BBD21963CE700165235 /* RNPReminder.m in Sources */,
 				669582121FE441A8008596CD /* RNPPhoto.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -213,6 +247,7 @@
 /* Begin XCBuildConfiguration section */
 		9D23B3561C767B80008B4819 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -237,9 +272,12 @@
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"$(RNP_SELECTIVE)",
+					"$(RNP_PERMISSION_TYPES)",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -256,6 +294,7 @@
 		};
 		9D23B3571C767B80008B4819 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -278,6 +317,11 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(RNP_SELECTIVE)",
+					"$(RNP_PERMISSION_TYPES)",
+				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -309,6 +353,7 @@
 		9D23B35A1C767B80008B4819 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "";
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",

--- a/ios/ReactNativePermissions.xcodeproj/project.pbxproj
+++ b/ios/ReactNativePermissions.xcodeproj/project.pbxproj
@@ -247,7 +247,6 @@
 /* Begin XCBuildConfiguration section */
 		9D23B3561C767B80008B4819 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -276,8 +275,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"$(RNP_SELECTIVE)",
-					"$(RNP_PERMISSION_TYPES)",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -294,7 +291,6 @@
 		};
 		9D23B3571C767B80008B4819 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -318,10 +314,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = NO;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(RNP_SELECTIVE)",
-					"$(RNP_PERMISSION_TYPES)",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -339,6 +332,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
+				CLANG_MODULES_AUTOLINK = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(RNP_PERMISSION_TYPES)",
+				);
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
@@ -355,6 +353,11 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8C1F8BB72196231700165235 /* RNPConfig.xcconfig */;
 			buildSettings = {
+				CLANG_MODULES_AUTOLINK = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"${RNP_PERMISSION_TYPES}",
+				);
 				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "";
 				HEADER_SEARCH_PATHS = (
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,


### PR DESCRIPTION
Now you can create RNPPermissions.xcconfig file in ios/ folder and provide preprocessor variables e.g.:
```
RNP_SELECTIVE = RNP_PERMISSIONS_SELECTIVE
RNP_PERMISSION_TYPES = RNP_TYPE_LOCATION RNP_TYPE_NOTIFICATION
```
Only code responsible for particular permission will be compiled in and no need to include all usage descriptions in Info.plist.

By default it includes all if RNP_PERMISSIONS_SELECTIVE not given, but I think in future it should be always a list of needed permission types.

Some refactoring done as well, docs will be added if will be some response from maintainer as this repo wasn't updated for some time.

To use this implementation:
```
"react-native-permissions": "github:flatfox-ag/react-native-permissions#7683bceac6f152d74e98574eb90916bad3b2363b",
```

Any feedback welcome.