### PR TITLE
read external storage photo

### DIFF
--- a/lib/permissions.android.js
+++ b/lib/permissions.android.js
@@ -14,7 +14,7 @@ const permissionTypes = {
   contacts: PermissionsAndroid.PERMISSIONS.READ_CONTACTS,
   event: PermissionsAndroid.PERMISSIONS.READ_CALENDAR,
   storage: PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
-  photo: PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+  photo: PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE,
   callPhone: PermissionsAndroid.PERMISSIONS.CALL_PHONE,
   readSms: PermissionsAndroid.PERMISSIONS.READ_SMS,
   receiveSms: PermissionsAndroid.PERMISSIONS.RECEIVE_SMS,


### PR DESCRIPTION
I think we want to use `READ_EXTERNAL_STORAGE` for photo instead of `WRITE_EXTERNAL_STORAGE`

Related issue: https://github.com/yonahforst/react-native-permissions/issues/253