### PR TITLE
Bundling fails when also targeting Windows UWP development

### DIFF
--- a/lib/permissions.windows.js
+++ b/lib/permissions.windows.js
@@ -1,0 +1,4 @@
+// This file is left blank intentionally. It's only purpose is to prevent the import statement from failing.
+
+export default {};
+


### PR DESCRIPTION
The permissions.js file does not have a windows version and therefore bundling the plugin fails when the React Native project also targets the Windows UWP (react-native-windows) framework.

The workaround is to add a redundant permissions.windows.js file in the lib folder.

The error message to clarify the whole story:
```
error: bundling failed: Error: Unable to resolve module `./lib/permissions` from `\node_modules\react-native-permissions\index.js`: The module `./lib/permissions` could not be found from `\node_modules\react-native-permissions\index.js`. Indeed, none of these files exist:
  * `\node_modules\react-native-permissions\lib\permissions(.native||.windows.js|.native.js|.js|.windows.json|.native.json|.json)`
  * `\node_modules\react-native-permissions\lib\permissions\index(.native||.windows.js|.native.js|.js|.windows.json|.native.json|.json)`
    at ModuleResolver.resolveDependency (\node_modules\metro\src\node-haste\DependencyGraph\ModuleResolution.js:161:851)
    at ResolutionRequest.resolveDependency (\node_modules\metro\src\node-haste\DependencyGraph\ResolutionRequest.js:91:16)
    at DependencyGraph.resolveDependency (\node_modules\metro\src\node-haste\DependencyGraph.js:272:4579)
    at dependencies.map.relativePath (\node_modules\metro\src\DeltaBundler\traverseDependencies.js:376:19)
    at Array.map (<anonymous>)
    at resolveDependencies (\node_modules\metro\src\DeltaBundler\traverseDependencies.js:374:16)
    at \node_modules\metro\src\DeltaBundler\traverseDependencies.js:212:33
    at Generator.next (<anonymous>)
    at step (\node_modules\metro\src\DeltaBundler\traverseDependencies.js:297:313)
    at \node_modules\metro\src\DeltaBundler\traverseDependencies.js:297:473
```