### PR TITLE
Can not found RNPStatusRestricted in iOS

### DIFF
--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -17,20 +17,23 @@
 
 @implementation RNPLocation
 
-+ (NSString *)getStatusForType:(NSString *)type
-{
-    int status = [CLLocationManager authorizationStatus];
-    switch (status) {
-        case kCLAuthorizationStatusAuthorizedAlways:
++ (NSString *)getStatusForType:(NSString *)type {
+    if ([CLLocationManager locationServicesEnabled]) {
+        int status = [CLLocationManager authorizationStatus];
+        switch (status) {
+            case kCLAuthorizationStatusAuthorizedAlways:
             return RNPStatusAuthorized;
-        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            case kCLAuthorizationStatusAuthorizedWhenInUse:
             return [type isEqualToString:@"always"] ? RNPStatusDenied : RNPStatusAuthorized;
-        case kCLAuthorizationStatusDenied:
+            case kCLAuthorizationStatusDenied:
             return RNPStatusDenied;
-        case kCLAuthorizationStatusRestricted:
+            case kCLAuthorizationStatusRestricted:
             return RNPStatusRestricted;
-        default:
+            default:
             return RNPStatusUndetermined;
+        }
+    }else{
+        return RNPStatusRestricted;
     }
 }
 


### PR DESCRIPTION
When "location Services" off from device the we have to return the status "RNPStatusRestricted" but it returns  "RNPStatusDenied".
So I aded "location Services" check also for "RNPStatusRestricted".