### PR TITLE
Add the tvOS platform to the podspec

### DIFF
--- a/ReactNativePermissions.podspec
+++ b/ReactNativePermissions.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors         = package["author"]
   s.homepage        = package["homepage"]
 
-  s.platform        = :ios, "9.0"
+  s.platforms       = { :ios => "9.0", :tvos => "11.0" }
   s.requires_arc    = true
 
   s.source          = { :git => package["repository"]["url"], :tag => s.version }


### PR DESCRIPTION
# Summary

The .podspec file was missing the tvOS platform.

## Test Plan

The change wat tested and used in a production ready app for tvOS/iOS

### What's required for testing (prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| tvOS     |    ✅     |

## Checklist

- [X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)