### PR TITLE
Add NSBluetoothAlwaysUsageDescription for iOS 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ If you need to submit your application to the AppStore, you need to add to your 
 So before submitting your app to the App Store, make sure that in your `Info.plist` you have the following keys:
 
 ```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>Some description</string>
+<!-- only need peripheral if target is less than iOS 13 -->
+<!-- https://developer.apple.com/documentation/bundleresources/information_property_list/nsbluetoothperipheralusagedescription -->
 <key>NSBluetoothPeripheralUsageDescription</key>
 <string>Some description</string>
 <key>NSCalendarsUsageDescription</key>


### PR DESCRIPTION
Need to add NSBluetoothAlwaysUsageDescription for iOS 13

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
TestFlight builds would get rejected because the proper key wasn't added.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
an iOS build that's submittable to TestFlight and pulls in react-native-permissions

### What are the steps to reproduce (after prerequisites)?
Try uploading a test flight build without the keys. An email from apple will say:

```
Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. The app's Info.plist file should contain a NSBluetoothAlwaysUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data.
```

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
