### PR TITLE
Fix named export of constants through index (fix breaking change in 2.0.1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,8 @@ export function requestNotifications(
 
 export * from './types';
 
+export {PERMISSIONS, RESULTS} from './constants';
+
 export default {
   PERMISSIONS,
   RESULTS,


### PR DESCRIPTION
# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

My app crashed after upgrading from v2.0.0 to v2.0.1 because `PERMISSIONS` and `RESULTS` were both undefined.

I am importing them directly like this:
```
import {
  check, request, PERMISSIONS, RESULTS,
} from 'react-native-permissions'
```

The bug was introduced in 067ef5d4c4bf86c0312dbce987a7488de80f3999 where these two constants are no longer exported as named exports through index.js, only through the default object.

## Test Plan

I have tested using the example app in this repo. I rewrote the App.tsx to not import the RNPermissions default, but only named exports. I verified that it crashed. I have also tested with my fix to verify that it worked.

### What's required for testing (prerequisites)?
Use react-native-permissions version 2.0.1 in an app and import `PERMISSIONS` and `RESULTS` like this: `import { PERMISSIONS, RESULTS } from 'react-native-permissions'`.

### What are the steps to reproduce (after prerequisites)?

Start your app, and check the value of `PERMISSIONS` or `RESULTS`. They are undefined. Likely your app crashes instantly because it cannot access `RESULTS.GRANTED`, or other values.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
