### PR TITLE
Fix path to AndroidManifest.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then update your `Info.plist` with wanted permissions usage descriptions:
 
 ### Android
 
-Add all wanted permissions to your app `android/app/src/main/res/AndroidManifest.xml` file:
+Add all wanted permissions to your app `android/app/src/main/AndroidManifest.xml` file:
 
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"


### PR DESCRIPTION
Fixes the path to `AndroidManifest.xml`. For example, see [the template of React Native v0.61.2](https://github.com/facebook/react-native/tree/v0.61.2/template) where the `AndroidManifest.xml` can be found in [`android/app/src/main`](https://github.com/facebook/react-native/tree/v0.61.2/template/android/app/src/main).