### PR TITLE
Hotfix: Prevent handler being ARC on iOS before resolving the request

### DIFF
--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -79,8 +79,6 @@ typedef enum {
 
 @interface RNPermissions : NSObject <RCTBridgeModule>
 
-@property (nonatomic, strong) NSMutableDictionary<NSString *, id<RNPermissionHandler>>  *_Nonnull handlers;
-
 + (bool)isFlaggedAsRequested:(NSString * _Nonnull)handlerId;
 
 + (void)flagAsRequested:(NSString * _Nonnull)handlerId;

--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -79,6 +79,8 @@ typedef enum {
 
 @interface RNPermissions : NSObject <RCTBridgeModule>
 
+@property (nonatomic, strong) NSMutableDictionary<NSString *, id<RNPermissionHandler>>  *_Nonnull handlers;
+
 + (bool)isFlaggedAsRequested:(NSString * _Nonnull)handlerId;
 
 + (void)flagAsRequested:(NSString * _Nonnull)handlerId;

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -104,6 +104,10 @@ RCT_ENUM_CONVERTER(RNPermission, (@{
 
 @end
 
+@interface RNPermissions ()
+@property (nonatomic, strong) NSMutableDictionary<NSString *, id<RNPermissionHandler>>  *_Nonnull handlers;
+@end
+
 @implementation RNPermissions
 
 RCT_EXPORT_MODULE();
@@ -226,13 +230,13 @@ RCT_EXPORT_MODULE();
 }
 
 - (NSString *)insertHandler:(id<RNPermissionHandler>)handler {
-    if( self.handlers == nil){
-        self.handlers = [NSMutableDictionary new];
+    if(_handlers == nil){
+        _handlers = [NSMutableDictionary new];
     }
     
     NSString *randomId = [[NSUUID UUID] UUIDString];
     
-    [self.handlers setObject:handler forKey:randomId];
+    [_handlers setObject:handler forKey:randomId];
     
     return randomId;
 }

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -225,6 +225,18 @@ RCT_EXPORT_MODULE();
   }
 }
 
+- (NSString *)insertHandler:(id<RNPermissionHandler>)handler {
+    if( self.handlers == nil){
+        self.handlers = [NSMutableDictionary new];
+    }
+    
+    NSString *randomId = [[NSUUID UUID] UUIDString];
+    
+    [self.handlers setObject:handler forKey:randomId];
+    
+    return randomId;
+}
+
 + (bool)isFlaggedAsRequested:(NSString * _Nonnull)handlerId {
   NSArray<NSString *> *requested = [[NSUserDefaults standardUserDefaults] arrayForKey:SETTING_KEY];
   return requested == nil ? false : [requested containsObject:handlerId];
@@ -271,13 +283,19 @@ RCT_REMAP_METHOD(check,
                  rejecter:(RCTPromiseRejectBlock)reject) {
   id<RNPermissionHandler> handler = [self handlerForPermission:permission];
 
+  NSString *randomId = [self insertHandler: handler];
+
   [handler checkWithResolver:^(RNPermissionStatus status) {
     NSString *strStatus = [self stringForStatus:status];
     NSLog(@"[react-native-permissions] %@ permission checked: %@", [[handler class] handlerUniqueId], strStatus);
     resolve(strStatus);
+
+    [self.handlers removeObjectForKey:randomId];
   } rejecter:^(NSError *error) {
     NSLog(@"[react-native-permissions] %@ permission failed: %@", [[handler class] handlerUniqueId], error.localizedDescription);
     reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+
+    [self.handlers removeObjectForKey:randomId];
   }];
 }
 
@@ -287,13 +305,19 @@ RCT_REMAP_METHOD(request,
                  rejecter:(RCTPromiseRejectBlock)reject) {
   id<RNPermissionHandler> handler = [self handlerForPermission:permission];
 
+  NSString *randomId = [self insertHandler: handler];
+
   [handler requestWithResolver:^(RNPermissionStatus status) {
     NSString *strStatus = [self stringForStatus:status];
     NSLog(@"[react-native-permissions] %@ permission checked: %@", [[handler class] handlerUniqueId], strStatus);
     resolve(strStatus);
+
+    [self.handlers removeObjectForKey:randomId];
   } rejecter:^(NSError *error) {
     NSLog(@"[react-native-permissions] %@ permission failed: %@", [[handler class] handlerUniqueId], error.localizedDescription);
     reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+
+    [self.handlers removeObjectForKey:randomId];
   }];
 }
 


### PR DESCRIPTION

# Summary

To resolve the problem of handler being ARC on iOS [#390 ]

- Create a strong reference in RNPermission.h
- Add a method to store handler in NSDictionary and return a random ID for disposing after use


## Test Plan

- Create a memory-consuming app
- Invoke Location permission request
- Old implement might get to a situation that the dialog dismiss itself before user action because of aggressive ARC
- New implementation will not encounter the issue as handler is now stored in a strong reference to prevent ARC

### What's required for testing (prerequisites)?
- A bulky app which cause the bug (Release mode only)

### What are the steps to reproduce (after prerequisites)?
- Invoke Location permission request

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌ (Not applicable)    |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
