### PR TITLE
Remove deprecated react-native link mentions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,10 +40,7 @@ const RNPermissions: {
 // Produce an error if we don't have the native module
 if (RNPermissions == null) {
   throw new Error(`react-native-permissions: NativeModule.RNPermissions is null. To fix this issue try these steps:
-• Run \`react-native link react-native-permissions\` in the project root.
-• Rebuild and re-run the app.
 • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app. You may also need to re-open Xcode to get the new pods.
-• Check that the library was linked correctly when you used the link command by running through the manual installation instructions in the README.
 * If you are getting this error while unit testing you need to mock the native module. Follow the guide in the README.
 If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-permissions`);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

`react-native link [package]` is deprecated in favor of autolinking, which is available since RN 0.60. Feel free to wait with merging it until you drop support for RN 0.59

## Test Plan

None, adjusting error message.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
