### PR TITLE
Fix compatibility with TypeScript versions < 3.8.0

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import {ANDROID, IOS, RESULTS} from './constants';
 
 type Values<T extends object> = T[keyof T];
 
-export type {Rationale} from 'react-native';
+export {Rationale} from 'react-native';
 
 export type AndroidPermission = Values<typeof ANDROID>;
 export type IOSPermission = Values<typeof IOS>;


### PR DESCRIPTION
# Summary

In the [2.1.0 release](https://github.com/react-native-community/react-native-permissions/commit/19840ab5b0536f04c86c11cd7f733291aeb201b9#diff-41df78d86ed4de80aae9b0b9560feb2bR5-R6) of react-native-permissions, this library now exports the `Rationale` type from `react-native` in `src/types.ts`. However, the syntax used for this is a type-only import, which is a [new feature in TypeScript 3.8](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/).

https://github.com/react-native-community/react-native-permissions/blob/19840ab/src/types.ts#L5-6

This may have been done pre-emptively, as not all projects will have yet updated to a compatible TypeScript version. Since this library ships uncompiled, this will cause a syntax error when parsed by the hosting project in versions of TypeScript that are below 3.8.0, and cannot easily be ignored.

**This PR removes the type-only import and converts it back to a standard TypeScript import. There are no features impacted.**

**Before changes**

![image](https://user-images.githubusercontent.com/2547783/80518233-205be780-897e-11ea-9b55-88535c7f4ae3.png)

**After changes in a host project**

    yarn tsc -w

![image](https://user-images.githubusercontent.com/2547783/80518119-f73b5700-897d-11ea-83f4-fba0961e5ac6.png)


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I updated the typed files (TS and Flow)
