### PR TITLE
README – Alternative to use_frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Then update your `Info.plist` with wanted permissions usage descriptions:
 ```
 
 #### Workaround for `use_frameworks!` issues
+`use_frameworks!` builds _all_ Pods as dynamic frameworks. react-native-permissions must be compiled as a static library.
 
 If you use `use_frameworks!`, add this at the top of your `Podfile`:
 
@@ -123,6 +124,8 @@ pre_install do |installer|
   end
 end
 ```
+
+Or as an alternative to `use_frameworks!`, use the [cocoapods-user-defined-build-types](https://github.com/joncardasis/cocoapods-user-defined-build-types) plugin to selectively mark other Pods as dynamic frameworks.
 
 ### Android
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Cocoapods `use_frameworks!` directive can cause problems with many RN projects, react-native-permissions included. Currently, the Readme offers a hacky workaround tied to specific versions of Cocoapods.

I've added a callout to the [cocoapods-user-defined-build-types](https://github.com/joncardasis/cocoapods-user-defined-build-types) plugin as a more stable alternative. **DISCLOSURE:** I am the maintainer of this plugin.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
N/A

### What are the steps to reproduce (after prerequisites)?
N/A

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
