### PR TITLE
Update iOS setup to include pod for RNPermissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ target 'YourAwesomeProject' do
 
   # …
 
+  pod 'RNPermissions', :path => "../node_modules/react-native-permissions"
   permissions_path = '../node_modules/react-native-permissions/ios'
 
   pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral.podspec"


### PR DESCRIPTION
Update README's setup for iOS: Add line to include core library in Podfile.

May save time for some.