### PR TITLE
Support ATT framework for iOS 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ target 'YourAwesomeProject' do
 
   permissions_path = '../node_modules/react-native-permissions/ios'
 
+  pod 'Permission-AppTrackingTransparency', :path => "#{permissions_path}/AppTrackingTransparency.podspec"
   pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral.podspec"
   pod 'Permission-Calendars', :path => "#{permissions_path}/Calendars.podspec"
   pod 'Permission-Camera', :path => "#{permissions_path}/Camera.podspec"
@@ -98,6 +99,8 @@ Then update your `Info.plist` with wanted permissions usage descriptions:
   <string>YOUR TEXT</string>
   <key>NSSiriUsageDescription</key>
   <string>YOUR TEXT</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>YOUR TEXT</string>
 
   <!-- … -->
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -94,6 +94,7 @@ target 'RNPermissionsExample' do
 
   permissions_path = '../node_modules/react-native-permissions/ios'
 
+  pod 'Permission-AppTrackingTransparency', :path => "#{permissions_path}/AppTrackingTransparency.podspec"
   pod 'Permission-BluetoothPeripheral', :path => "#{permissions_path}/BluetoothPeripheral.podspec"
   pod 'Permission-Calendars', :path => "#{permissions_path}/Calendars.podspec"
   pod 'Permission-Camera', :path => "#{permissions_path}/Camera.podspec"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -70,6 +70,8 @@ PODS:
   - OpenSSL-Universal (1.0.2.19):
     - OpenSSL-Universal/Static (= 1.0.2.19)
   - OpenSSL-Universal/Static (1.0.2.19)
+  - Permission-AppTrackingTransparency (2.1.5):
+    - RNPermissions
   - Permission-BluetoothPeripheral (2.1.5):
     - RNPermissions
   - Permission-Calendars (2.1.5):
@@ -355,6 +357,7 @@ DEPENDENCIES:
   - FlipperKit/SKIOSNetworkPlugin (~> 0.33.1)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
+  - Permission-AppTrackingTransparency (from `../node_modules/react-native-permissions/ios/AppTrackingTransparency.podspec`)
   - Permission-BluetoothPeripheral (from `../node_modules/react-native-permissions/ios/BluetoothPeripheral.podspec`)
   - Permission-Calendars (from `../node_modules/react-native-permissions/ios/Calendars.podspec`)
   - Permission-Camera (from `../node_modules/react-native-permissions/ios/Camera.podspec`)
@@ -422,6 +425,8 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/Folly.podspec"
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
+  Permission-AppTrackingTransparency:
+    :path: "../node_modules/react-native-permissions/ios/AppTrackingTransparency.podspec"
   Permission-BluetoothPeripheral:
     :path: "../node_modules/react-native-permissions/ios/BluetoothPeripheral.podspec"
   Permission-Calendars:
@@ -514,6 +519,7 @@ SPEC CHECKSUMS:
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+  Permission-AppTrackingTransparency: e9c0edf423abffca2fddee9cd8ed55e9cc7133df
   Permission-BluetoothPeripheral: 4663a8373072abfe3099c44cb06bf10b0c16c110
   Permission-Calendars: dc345e3388149514603309c621151ff3cfd5816a
   Permission-Camera: afad27bf90337684d4a86f3825112d648c8c4d3b
@@ -553,6 +559,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 48265109032bce1863187d238dd58c9e3563d7e5
+PODFILE CHECKSUM: 33d4013cd5154539040dffe614d959a536bc61f4
 
 COCOAPODS: 1.9.1

--- a/example/ios/RNPermissionsExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNPermissionsExample.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = RNPermissionsExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNPermissionsExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNPermissionsExample/main.m; sourceTree = "<group>"; };
+		59DCBBDF24EE5AF000FEBE51 /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
 		615E8FE35802E6D32ADCFD4C /* Pods-RNPermissionsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPermissionsExample.debug.xcconfig"; path = "Target Support Files/Pods-RNPermissionsExample/Pods-RNPermissionsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		C6AF97F3E23718347362F9AB /* Pods-RNPermissionsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPermissionsExample.release.xcconfig"; path = "Target Support Files/Pods-RNPermissionsExample/Pods-RNPermissionsExample.release.xcconfig"; sourceTree = "<group>"; };
 		D1B2CF7CB21D0A588199C895 /* libPods-RNPermissionsExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNPermissionsExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -68,6 +69,7 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				59DCBBDF24EE5AF000FEBE51 /* AppTrackingTransparency.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
 				D1B2CF7CB21D0A588199C895 /* libPods-RNPermissionsExample.a */,

--- a/example/ios/RNPermissionsExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNPermissionsExample.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = RNPermissionsExample/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = RNPermissionsExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = RNPermissionsExample/main.m; sourceTree = "<group>"; };
-		59DCBBDF24EE5AF000FEBE51 /* AppTrackingTransparency.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppTrackingTransparency.framework; path = System/Library/Frameworks/AppTrackingTransparency.framework; sourceTree = SDKROOT; };
 		615E8FE35802E6D32ADCFD4C /* Pods-RNPermissionsExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPermissionsExample.debug.xcconfig"; path = "Target Support Files/Pods-RNPermissionsExample/Pods-RNPermissionsExample.debug.xcconfig"; sourceTree = "<group>"; };
 		C6AF97F3E23718347362F9AB /* Pods-RNPermissionsExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNPermissionsExample.release.xcconfig"; path = "Target Support Files/Pods-RNPermissionsExample/Pods-RNPermissionsExample.release.xcconfig"; sourceTree = "<group>"; };
 		D1B2CF7CB21D0A588199C895 /* libPods-RNPermissionsExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNPermissionsExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -69,7 +68,6 @@
 		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				59DCBBDF24EE5AF000FEBE51 /* AppTrackingTransparency.framework */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
 				ED2971642150620600B7C4FE /* JavaScriptCore.framework */,
 				D1B2CF7CB21D0A588199C895 /* libPods-RNPermissionsExample.a */,

--- a/ios/AppTrackingTransparency.podspec
+++ b/ios/AppTrackingTransparency.podspec
@@ -1,0 +1,21 @@
+require 'json'
+package = JSON.parse(File.read('../package.json'))
+
+Pod::Spec.new do |s|
+  s.name                      = "Permission-AppTrackingTransparency"
+  s.dependency                  "RNPermissions"
+
+  s.version                   = package["version"]
+  s.license                   = package["license"]
+  s.summary                   = package["description"]
+  s.authors                   = package["author"]
+  s.homepage                  = package["homepage"]
+
+  s.platform                  = :ios, "9.0"
+  s.ios.deployment_target     = "9.0"
+  s.tvos.deployment_target    = "11.0"
+  s.requires_arc              = true
+
+  s.source                    = { :git => package["repository"]["url"], :tag => s.version }
+  s.source_files              = "AppTrackingTransparency/*.{h,m}"
+end

--- a/ios/AppTrackingTransparency.podspec
+++ b/ios/AppTrackingTransparency.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
 
   s.source                    = { :git => package["repository"]["url"], :tag => s.version }
   s.source_files              = "AppTrackingTransparency/*.{h,m}"
+  s.frameworks                = "AppTrackingTransparency"
 end

--- a/ios/AppTrackingTransparency/RNPermissionHandlerAppTrackingTransparency.h
+++ b/ios/AppTrackingTransparency/RNPermissionHandlerAppTrackingTransparency.h
@@ -1,0 +1,5 @@
+#import "RNPermissions.h"
+
+@interface RNPermissionHandlerAppTrackingTransparency : NSObject<RNPermissionHandler>
+
+@end

--- a/ios/AppTrackingTransparency/RNPermissionHandlerAppTrackingTransparency.m
+++ b/ios/AppTrackingTransparency/RNPermissionHandlerAppTrackingTransparency.m
@@ -1,0 +1,50 @@
+#import "RNPermissionHandlerAppTrackingTransparency.h"
+
+@import AppTrackingTransparency;
+@import AdSupport;
+
+@implementation RNPermissionHandlerAppTrackingTransparency
+
++ (NSArray<NSString *> * _Nonnull)usageDescriptionKeys {
+  return @[@"NSUserTrackingUsageDescription"];
+}
+
++ (NSString * _Nonnull)handlerUniqueId {
+  return @"ios.permission.APP_TRACKING_TRANSPARENCY";
+}
+
+- (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                 rejecter:(void (__unused ^ _Nonnull)(NSError * _Nonnull))reject {
+    if (@available(iOS 14.0, *)) {
+      switch ([ATTrackingManager trackingAuthorizationStatus]) {
+        case ATTrackingManagerAuthorizationStatusNotDetermined:
+          return resolve(RNPermissionStatusNotDetermined);
+        case ATTrackingManagerAuthorizationStatusRestricted:
+          return resolve(RNPermissionStatusRestricted);
+        case ATTrackingManagerAuthorizationStatusDenied:
+          return resolve(RNPermissionStatusDenied);
+        case ATTrackingManagerAuthorizationStatusAuthorized:
+          return resolve(RNPermissionStatusAuthorized);
+      }
+    } else {
+        NSString *idfaString = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+        if ([idfaString isEqualToString:@"00000000-0000-0000-0000-000000000000"]) {
+            return resolve(RNPermissionStatusDenied);
+        }
+        
+        resolve(RNPermissionStatusAuthorized);
+    }
+}
+
+- (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+  if (@available(iOS 14.0, *)) {
+    [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(__unused ATTrackingManagerAuthorizationStatus status) {
+        [self checkWithResolver:resolve rejecter:reject];
+    }];
+  } else {
+      [self checkWithResolver:resolve rejecter:reject];
+  }
+}
+
+@end

--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -48,6 +48,9 @@ typedef NS_ENUM(NSInteger, RNPermission) {
 #if __has_include("RNPermissionHandlerStoreKit.h")
   RNPermissionStoreKit = 15,
 #endif
+#if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
+  RNPermissionAppTrackingTransparency = 16,
+#endif
 };
 
 @interface RCTConvert (RNPermission)

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -49,6 +49,9 @@
 #if __has_include("RNPermissionHandlerStoreKit.h")
 #import "RNPermissionHandlerStoreKit.h"
 #endif
+#if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
+#import "RNPermissionHandlerAppTrackingTransparency.h"
+#endif
 
 static NSString* SETTING_KEY = @"@RNPermissions:Requested";
 
@@ -99,6 +102,9 @@ RCT_ENUM_CONVERTER(RNPermission, (@{
 #endif
 #if __has_include("RNPermissionHandlerStoreKit.h")
   [RNPermissionHandlerStoreKit handlerUniqueId]: @(RNPermissionStoreKit),
+#endif
+#if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
+  [RNPermissionHandlerAppTrackingTransparency handlerUniqueId]: @(RNPermissionAppTrackingTransparency),
 #endif
 }), RNPermissionUnknown, integerValue);
 
@@ -172,6 +178,9 @@ RCT_EXPORT_MODULE();
 #endif
 #if __has_include("RNPermissionHandlerStoreKit.h")
   [available addObject:[RNPermissionHandlerStoreKit handlerUniqueId]];
+#endif
+#if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
+  [available addObject:[RNPermissionHandlerAppTrackingTransparency handlerUniqueId]];
 #endif
 
 #if RCT_DEV
@@ -267,6 +276,11 @@ RCT_EXPORT_MODULE();
 #if __has_include("RNPermissionHandlerStoreKit.h")
     case RNPermissionStoreKit:
       handler = [RNPermissionHandlerStoreKit new];
+      break;
+#endif
+#if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
+    case RNPermissionAppTrackingTransparency:
+      handler = [RNPermissionHandlerAppTrackingTransparency new];
       break;
 #endif
     case RNPermissionUnknown:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,6 +31,7 @@ export const ANDROID = Object.freeze({
 });
 
 export const IOS = Object.freeze({
+  APP_TRACKING_TRANSPARENCY: 'ios.permission.APP_TRACKING_TRANSPARENCY' as const,
   BLUETOOTH_PERIPHERAL: 'ios.permission.BLUETOOTH_PERIPHERAL' as const,
   CALENDARS: 'ios.permission.CALENDARS' as const,
   CAMERA: 'ios.permission.CAMERA' as const,


### PR DESCRIPTION
# Summary

With iOS 14 launching soon, it'll be useful to support the AppTrackingTransparency framework to display the prompt for the user to allow the app to track them (and make the IDFA available).

FIxes #500 

## Test Plan

### What's required for testing (prerequisites)?

- iOS 14 beta 5 
- Xcode Version 12.0 beta 5

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |   ❌    |

## Checklist

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)

**Note:** Since the framework requires Xcode 12 beta 5 and iOS 14, we should wait for iOS 14 to launch otherwise react-native run-ios will fail for users unless they use xcode 12 to build. Alternatively, this could be a beta feature.