### PR TITLE
Location full accuracy (issue #489)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ check(PERMISSIONS.IOS.LOCATION_ALWAYS)
 Request one permission.
 
 ```ts
-type RationaleAndroid = {
+type Rationale = {
   title: string;
   message: string;
   buttonPositive?: string;
@@ -473,13 +473,13 @@ type RationaleAndroid = {
   buttonNeutral?: string;
 };
 
-type RationalFullAccuracyIOS {
+type FullAccuracyOptionsIOS {
   temporaryPurposeKey: string
 }
 
 function request(
   permission: string,
-  rationale?: RationaleAndroid | RationalFullAccuracyIOS,
+  options?: Rationale | FullAccuracyOptionsIOS,
 ): Promise<PermissionStatus>;
 ```
 

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ check(PERMISSIONS.IOS.LOCATION_ALWAYS)
 Request one permission.
 
 ```ts
-type Rationale = {
+type RationaleAndroid = {
   title: string;
   message: string;
   buttonPositive?: string;
@@ -469,9 +469,13 @@ type Rationale = {
   buttonNeutral?: string;
 };
 
+type RationalFullAccuracyIOS {
+  temporaryPurposeKey: string
+}
+
 function request(
   permission: string,
-  rationale?: Rationale,
+  rationale?: RationaleAndroid | RationalFullAccuracyIOS,
 ): Promise<PermissionStatus>;
 ```
 
@@ -558,28 +562,6 @@ import {requestNotifications} from 'react-native-permissions';
 requestNotifications(['alert', 'sound']).then(({status, settings}) => {
   // …
 });
-```
-
----
-
-#### requestLocationTemporaryFullAccuracy
-
-Requests temporary precise location tracking on iOS, using the provided purpose key.
-
-```ts
-function requestLocationTemporaryFullAccuracy(options: {
-  purposeKey: string;
-}): Promise<PermissionStatus>;
-```
-
-```js
-import {requestNotifications} from 'react-native-permissions';
-
-requestLocationTemporaryFullAccuracy({purposeKey: 'YOUR-PURPOSE-KEY'}).then(
-  (status) => {
-    // …
-  },
-);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Then update your `Info.plist` with wanted permissions usage descriptions:
   <string>YOUR TEXT</string>
   <key>NSLocationWhenInUseUsageDescription</key>
   <string>YOUR TEXT</string>
+  <key>NSLocationTemporaryUsageDescriptionDictionary</key>
+	<dict>
+		<key>YOUR-PURPOSE-KEY</key>
+		<string>YOUR TEXT</string>
+	</dict>
   <key>NSMicrophoneUsageDescription</key>
   <string>YOUR TEXT</string>
   <key>NSMotionUsageDescription</key>
@@ -383,6 +388,7 @@ PERMISSIONS.IOS.CONTACTS;
 PERMISSIONS.IOS.FACE_ID;
 PERMISSIONS.IOS.LOCATION_ALWAYS;
 PERMISSIONS.IOS.LOCATION_WHEN_IN_USE;
+PERMISSIONS.IOS.LOCATION_FULL_ACCURACY;
 PERMISSIONS.IOS.MEDIA_LIBRARY;
 PERMISSIONS.IOS.MICROPHONE;
 PERMISSIONS.IOS.MOTION;
@@ -485,7 +491,7 @@ Check notifications permission status and get notifications settings values.
 
 ```ts
 interface NotificationSettings {
-  // properties only availables on iOS
+  // properties only available on iOS
   // unavailable settings will not be included in the response object
   alert?: boolean;
   badge?: boolean;
@@ -527,7 +533,7 @@ type NotificationOption =
   | 'provisional';
 
 interface NotificationSettings {
-  // properties only availables on iOS
+  // properties only available on iOS
   // unavailable settings will not be included in the response object
   alert?: boolean;
   badge?: boolean;
@@ -552,6 +558,28 @@ import {requestNotifications} from 'react-native-permissions';
 requestNotifications(['alert', 'sound']).then(({status, settings}) => {
   // …
 });
+```
+
+---
+
+#### requestLocationTemporaryFullAccuracy
+
+Requests temporary precise location tracking on iOS, using the provided purpose key.
+
+```ts
+function requestLocationTemporaryFullAccuracy(options: {
+  purposeKey: string;
+}): Promise<PermissionStatus>;
+```
+
+```js
+import {requestNotifications} from 'react-native-permissions';
+
+requestLocationTemporaryFullAccuracy({purposeKey: 'YOUR-PURPOSE-KEY'}).then(
+  (status) => {
+    // …
+  },
+);
 ```
 
 ---

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -189,13 +189,7 @@ export default class App extends React.Component<{}, State> {
         status={status}
         name={item}
         onPress={() => {
-          const request =
-            value === PERMISSIONS.IOS.LOCATION_FULL_ACCURACY
-              ? RNPermissions.request(value, {
-                  temporaryPurposeKey: 'full-accuracy',
-                })
-              : RNPermissions.request(value);
-          request
+          RNPermissions.request(value)
             .then(() => this.check())
             .catch((error) => console.error(error));
         }}

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import {FlatList, Platform, StatusBar, Text, View} from 'react-native';
+import {
+  AppState,
+  FlatList,
+  ListRenderItemInfo,
+  Platform,
+  StatusBar,
+  Text,
+  View,
+} from 'react-native';
 import {Appbar, List, TouchableRipple} from 'react-native-paper';
 import RNPermissions, {
   NotificationsResponse,
@@ -90,6 +98,11 @@ export default class App extends React.Component<{}, State> {
 
   componentDidMount() {
     this.check();
+    AppState.addEventListener('change', this.check);
+  }
+
+  componentWillUnmount() {
+    AppState.removeEventListener('change', this.check);
   }
 
   render() {
@@ -121,27 +134,8 @@ export default class App extends React.Component<{}, State> {
 
         <FlatList
           keyExtractor={(item) => item}
-          data={Object.keys(PLATFORM_PERMISSIONS)}
-          renderItem={({item, index}) => {
-            const value = PERMISSIONS_VALUES[index];
-            const status = this.state.statuses[value];
-
-            if (!status) {
-              return null;
-            }
-
-            return (
-              <PermissionRow
-                status={status}
-                name={item}
-                onPress={() => {
-                  RNPermissions.request(value)
-                    .then(() => this.check())
-                    .catch((error) => console.error(error));
-                }}
-              />
-            );
-          }}
+          data={PERMISSIONS_VALUES}
+          renderItem={this.renderPermissionItem}
         />
 
         <View
@@ -181,4 +175,33 @@ export default class App extends React.Component<{}, State> {
       </View>
     );
   }
+
+  renderPermissionItem = ({item, index}: ListRenderItemInfo<Permission>) => {
+    const value = PERMISSIONS_VALUES[index];
+    const status = this.state.statuses[value];
+
+    if (!status) {
+      return null;
+    }
+
+    return (
+      <PermissionRow
+        status={status}
+        name={item}
+        onPress={() => {
+          if (value === PERMISSIONS.IOS.LOCATION_FULL_ACCURACY) {
+            RNPermissions.requestLocationTemporaryFullAccuracy({
+              purposeKey: 'full-accuracy',
+            })
+              .then(() => this.check())
+              .catch((error) => console.error(error));
+          } else {
+            RNPermissions.request(value)
+              .then(() => this.check())
+              .catch((error) => console.error(error));
+          }
+        }}
+      />
+    );
+  };
 }

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -189,17 +189,15 @@ export default class App extends React.Component<{}, State> {
         status={status}
         name={item}
         onPress={() => {
-          if (value === PERMISSIONS.IOS.LOCATION_FULL_ACCURACY) {
-            RNPermissions.requestLocationTemporaryFullAccuracy({
-              purposeKey: 'full-accuracy',
-            })
-              .then(() => this.check())
-              .catch((error) => console.error(error));
-          } else {
-            RNPermissions.request(value)
-              .then(() => this.check())
-              .catch((error) => console.error(error));
-          }
+          const request =
+            value === PERMISSIONS.IOS.LOCATION_FULL_ACCURACY
+              ? RNPermissions.request(value, {
+                  temporaryPurposeKey: 'full-accuracy',
+                })
+              : RNPermissions.request(value);
+          request
+            .then(() => this.check())
+            .catch((error) => console.error(error));
         }}
       />
     );

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -101,6 +101,7 @@ target 'RNPermissionsExample' do
   pod 'Permission-FaceID', :path => "#{permissions_path}/FaceID.podspec"
   pod 'Permission-LocationAlways', :path => "#{permissions_path}/LocationAlways.podspec"
   pod 'Permission-LocationWhenInUse', :path => "#{permissions_path}/LocationWhenInUse.podspec"
+  pod 'Permission-LocationFullAccuracy', :path => "#{permissions_path}/LocationFullAccuracy.podspec"
   pod 'Permission-MediaLibrary', :path => "#{permissions_path}/MediaLibrary.podspec"
   pod 'Permission-Microphone', :path => "#{permissions_path}/Microphone.podspec"
   pod 'Permission-Motion', :path => "#{permissions_path}/Motion.podspec"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -82,6 +82,8 @@ PODS:
     - RNPermissions
   - Permission-LocationAlways (2.1.5):
     - RNPermissions
+  - Permission-LocationFullAccuracy (2.1.5):
+    - RNPermissions
   - Permission-LocationWhenInUse (2.1.5):
     - RNPermissions
   - Permission-MediaLibrary (2.1.5):
@@ -361,6 +363,7 @@ DEPENDENCIES:
   - Permission-Contacts (from `../node_modules/react-native-permissions/ios/Contacts.podspec`)
   - Permission-FaceID (from `../node_modules/react-native-permissions/ios/FaceID.podspec`)
   - Permission-LocationAlways (from `../node_modules/react-native-permissions/ios/LocationAlways.podspec`)
+  - Permission-LocationFullAccuracy (from `../node_modules/react-native-permissions/ios/LocationFullAccuracy.podspec`)
   - Permission-LocationWhenInUse (from `../node_modules/react-native-permissions/ios/LocationWhenInUse.podspec`)
   - Permission-MediaLibrary (from `../node_modules/react-native-permissions/ios/MediaLibrary.podspec`)
   - Permission-Microphone (from `../node_modules/react-native-permissions/ios/Microphone.podspec`)
@@ -434,6 +437,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-permissions/ios/FaceID.podspec"
   Permission-LocationAlways:
     :path: "../node_modules/react-native-permissions/ios/LocationAlways.podspec"
+  Permission-LocationFullAccuracy:
+    :path: "../node_modules/react-native-permissions/ios/LocationFullAccuracy.podspec"
   Permission-LocationWhenInUse:
     :path: "../node_modules/react-native-permissions/ios/LocationWhenInUse.podspec"
   Permission-MediaLibrary:
@@ -520,6 +525,7 @@ SPEC CHECKSUMS:
   Permission-Contacts: edde2d433382b3118f0d4c9ebc7708d5d87c4f17
   Permission-FaceID: fbdeb41087f35887f0cade55396007fadee3a234
   Permission-LocationAlways: 155e6251b757b380f6354737cae8e8d59c472495
+  Permission-LocationFullAccuracy: 661c56f2e7d8a79ff2709326265ec70ca7b969ee
   Permission-LocationWhenInUse: 3624cf08c12c6019926aba3054efee7f4f8ee91e
   Permission-MediaLibrary: dd1c48888cd95961fbfebdaebf8d4127c6e92e7d
   Permission-Microphone: 0ffabc3fe1c75cfb260525ee3f529383c9f4368c
@@ -553,6 +559,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 48265109032bce1863187d238dd58c9e3563d7e5
+PODFILE CHECKSUM: 9e96e19d5067985facb6a376a9c1fc970d97e8db
 
 COCOAPODS: 1.9.1

--- a/example/ios/RNPermissionsExample/Info.plist
+++ b/example/ios/RNPermissionsExample/Info.plist
@@ -57,6 +57,11 @@
 	<string>Let me use your location, even in background</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Let me use your location when the app is opened</string>
+	<key>NSLocationTemporaryUsageDescriptionDictionary</key>
+	<dict>
+		<key>full-accuracy</key>
+		<string>Let me use your precise location temporarily</string>
+	</dict>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Let me use the microphone</string>
 	<key>NSMotionUsageDescription</key>

--- a/ios/AppTrackingTransparency/RNPermissionHandlerAppTrackingTransparency.m
+++ b/ios/AppTrackingTransparency/RNPermissionHandlerAppTrackingTransparency.m
@@ -39,7 +39,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (@available(iOS 14.0, *)) {
     [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler:^(__unused ATTrackingManagerAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/ios/BluetoothPeripheral/RNPermissionHandlerBluetoothPeripheral.m
+++ b/ios/BluetoothPeripheral/RNPermissionHandlerBluetoothPeripheral.m
@@ -57,7 +57,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
 #if TARGET_OS_SIMULATOR
   return resolve(RNPermissionStatusNotAvailable);
 #else

--- a/ios/BluetoothPeripheral/RNPermissionHandlerBluetoothPeripheral.m
+++ b/ios/BluetoothPeripheral/RNPermissionHandlerBluetoothPeripheral.m
@@ -56,7 +56,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
 #if TARGET_OS_SIMULATOR
   return resolve(RNPermissionStatusNotAvailable);
 #else

--- a/ios/Calendars/RNPermissionHandlerCalendars.m
+++ b/ios/Calendars/RNPermissionHandlerCalendars.m
@@ -27,7 +27,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   [[EKEventStore new] requestAccessToEntityType:EKEntityTypeEvent
                                      completion:^(__unused BOOL granted, NSError * _Nullable error) {
     if (error != nil) {

--- a/ios/Calendars/RNPermissionHandlerCalendars.m
+++ b/ios/Calendars/RNPermissionHandlerCalendars.m
@@ -28,7 +28,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   [[EKEventStore new] requestAccessToEntityType:EKEntityTypeEvent
                                      completion:^(__unused BOOL granted, NSError * _Nullable error) {
     if (error != nil) {

--- a/ios/Camera/RNPermissionHandlerCamera.m
+++ b/ios/Camera/RNPermissionHandlerCamera.m
@@ -27,7 +27,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
                            completionHandler:^(__unused BOOL granted) {
     [self checkWithResolver:resolve rejecter:reject];

--- a/ios/Camera/RNPermissionHandlerCamera.m
+++ b/ios/Camera/RNPermissionHandlerCamera.m
@@ -28,7 +28,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo
                            completionHandler:^(__unused BOOL granted) {
     [self checkWithResolver:resolve rejecter:reject];

--- a/ios/Contacts/RNPermissionHandlerContacts.m
+++ b/ios/Contacts/RNPermissionHandlerContacts.m
@@ -28,7 +28,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   [[CNContactStore new] requestAccessForEntityType:CNEntityTypeContacts
                                  completionHandler:^(__unused BOOL granted, NSError * _Nullable error) {
     if (error != nil && error.code != 100) { // error code 100 is permission denied

--- a/ios/Contacts/RNPermissionHandlerContacts.m
+++ b/ios/Contacts/RNPermissionHandlerContacts.m
@@ -27,7 +27,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   [[CNContactStore new] requestAccessForEntityType:CNEntityTypeContacts
                                  completionHandler:^(__unused BOOL granted, NSError * _Nullable error) {
     if (error != nil && error.code != 100) { // error code 100 is permission denied

--- a/ios/FaceID/RNPermissionHandlerFaceID.m
+++ b/ios/FaceID/RNPermissionHandlerFaceID.m
@@ -52,7 +52,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (@available(iOS 11.0.1, *)) {
     LAContext *context = [LAContext new];
     NSError *error;

--- a/ios/FaceID/RNPermissionHandlerFaceID.m
+++ b/ios/FaceID/RNPermissionHandlerFaceID.m
@@ -53,7 +53,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (@available(iOS 11.0.1, *)) {
     LAContext *context = [LAContext new];
     NSError *error;

--- a/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
+++ b/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
@@ -44,7 +44,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }

--- a/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
+++ b/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
@@ -45,7 +45,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }

--- a/ios/LocationFullAccuracy.podspec
+++ b/ios/LocationFullAccuracy.podspec
@@ -1,0 +1,21 @@
+require 'json'
+package = JSON.parse(File.read('../package.json'))
+
+Pod::Spec.new do |s|
+  s.name                      = "Permission-LocationFullAccuracy"
+  s.dependency                  "RNPermissions"
+
+  s.version                   = package["version"]
+  s.license                   = package["license"]
+  s.summary                   = package["description"]
+  s.authors                   = package["author"]
+  s.homepage                  = package["homepage"]
+
+  s.platform                  = :ios, "9.0"
+  s.ios.deployment_target     = "9.0"
+  s.tvos.deployment_target    = "11.0"
+  s.requires_arc              = true
+
+  s.source                    = { :git => package["repository"]["url"], :tag => s.version }
+  s.source_files              = "LocationFullAccuracy/*.{h,m}"
+end

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.h
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.h
@@ -1,0 +1,19 @@
+#import "RNPermissions.h"
+
+@interface RNPermissionHandlerLocationFullAccuracy : NSObject<RNPermissionHandler>
+
++ (NSArray<NSString *> * _Nonnull)usageDescriptionKeys;
+
++ (NSString * _Nonnull)handlerUniqueId;
+
+- (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
+                 rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject;
+
+- (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject;
+
+- (void)requestTemporaryWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
+                            rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject
+                          purposeKey:(NSString * _Nonnull)purposeKey;
+
+@end

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.h
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.h
@@ -2,18 +2,4 @@
 
 @interface RNPermissionHandlerLocationFullAccuracy : NSObject<RNPermissionHandler>
 
-+ (NSArray<NSString *> * _Nonnull)usageDescriptionKeys;
-
-+ (NSString * _Nonnull)handlerUniqueId;
-
-- (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
-                 rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject;
-
-- (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject;
-
-- (void)requestTemporaryWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
-                            rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject
-                          purposeKey:(NSString * _Nonnull)purposeKey;
-
 @end

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
@@ -36,7 +36,7 @@ NS_ENUM(NSInteger) {
 
 - (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                  rejecter:(void (__unused ^ _Nonnull)(NSError * _Nonnull))reject {
-  if (!CLLocationManager.locationServicesEnabled || CLLocationManager.authorizationStatus != RNPermissionStatusAuthorized) {
+  if (!CLLocationManager.locationServicesEnabled) {
     return resolve(RNPermissionStatusNotAvailable);
   }
 
@@ -51,7 +51,7 @@ NS_ENUM(NSInteger) {
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
                   rationale:(NSDictionary *_Nullable)rationale {
-  if (!CLLocationManager.locationServicesEnabled || CLLocationManager.authorizationStatus != RNPermissionStatusAuthorized) {
+  if (!CLLocationManager.locationServicesEnabled) {
     return resolve(RNPermissionStatusNotAvailable);
   }
 

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
@@ -50,19 +50,17 @@ NS_ENUM(NSInteger) {
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (!CLLocationManager.locationServicesEnabled) {
     return resolve(RNPermissionStatusNotAvailable);
   }
 
   if (@available(iOS 14.0, *)) {
     CLLocationManager *locationManager = [CLLocationManager new];
-    NSString *purposeKey = [rationale objectForKey:@"temporaryPurposeKey"];
+    NSString *purposeKey = [options objectForKey:@"temporaryPurposeKey"];
 
     if (!purposeKey) {
-      return reject([NSError errorWithDomain:RNPermissionHandlerLocationFullAccuracyDomain
-                                        code:RNPermissionHandlerLocationFullAccuracyNoPurposeKey
-                                    userInfo:@{NSLocalizedDescriptionKey: @"temporaryPurposeKey is required to request LOCATION_FULL_ACCURACY"}]);
+      purposeKey = @"full-accuracy";
     }
 
     [locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
@@ -25,7 +25,7 @@
       return RNPermissionStatusAuthorized;
     case CLAccuracyAuthorizationReducedAccuracy:
     default:
-      return RNPermissionStatusDenied;
+      return RNPermissionStatusNotDetermined;
   }
 }
 
@@ -44,21 +44,15 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
-  // It is not possible to request full accuracy permanently within the app.  Either prompt user
-  // to open settings or request temporary full accuracy.
-  return resolve(RNPermissionStatusDenied);
-}
-
-- (void)requestTemporaryWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                            rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                          purposeKey:(NSString * _Nonnull)purposeKey {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (!CLLocationManager.locationServicesEnabled || CLLocationManager.authorizationStatus != RNPermissionStatusAuthorized) {
     return resolve(RNPermissionStatusNotAvailable);
   }
 
   if (@available(iOS 14.0, *)) {
     CLLocationManager *locationManager = [CLLocationManager new];
+    NSString *purposeKey = [rationale objectForKey:@"temporaryPurposeKey"];
     [locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey
                                                                   completion:^(NSError * _Nullable error) {
       RNPermissionStatus status = [RNPermissionHandlerLocationFullAccuracy getAccuracyStatus:locationManager];

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
@@ -3,6 +3,11 @@
 @import CoreLocation;
 @import UIKit;
 
+NSErrorDomain const RNPermissionHandlerLocationFullAccuracyDomain = @"RNPermissionHandlerLocationFullAccuracy";
+NS_ENUM(NSInteger) {
+  RNPermissionHandlerLocationFullAccuracyNoPurposeKey = 1,
+};
+
 @interface RNPermissionHandlerLocationFullAccuracy()
 
 @end
@@ -53,6 +58,13 @@
   if (@available(iOS 14.0, *)) {
     CLLocationManager *locationManager = [CLLocationManager new];
     NSString *purposeKey = [rationale objectForKey:@"temporaryPurposeKey"];
+
+    if (!purposeKey) {
+      return reject([NSError errorWithDomain:RNPermissionHandlerLocationFullAccuracyDomain
+                                        code:RNPermissionHandlerLocationFullAccuracyNoPurposeKey
+                                    userInfo:@{NSLocalizedDescriptionKey: @"temporaryPurposeKey is required to request LOCATION_FULL_ACCURACY"}]);
+    }
+
     [locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey
                                                                   completion:^(NSError * _Nullable error) {
       RNPermissionStatus status = [RNPermissionHandlerLocationFullAccuracy getAccuracyStatus:locationManager];

--- a/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
+++ b/ios/LocationFullAccuracy/RNPermissionHandlerLocationFullAccuracy.m
@@ -1,0 +1,74 @@
+#import "RNPermissionHandlerLocationFullAccuracy.h"
+
+@import CoreLocation;
+@import UIKit;
+
+@interface RNPermissionHandlerLocationFullAccuracy()
+
+@end
+
+@implementation RNPermissionHandlerLocationFullAccuracy
+
++ (NSArray<NSString *> * _Nonnull)usageDescriptionKeys {
+  return @[
+    @"NSLocationTemporaryUsageDescriptionDictionary"
+  ];
+}
+
++ (NSString * _Nonnull)handlerUniqueId {
+  return @"ios.permission.LOCATION_FULL_ACCURACY";
+}
+
++ (RNPermissionStatus)getAccuracyStatus:(CLLocationManager *)locationManager API_AVAILABLE(ios(14.0)) {
+  switch (locationManager.accuracyAuthorization) {
+    case CLAccuracyAuthorizationFullAccuracy:
+      return RNPermissionStatusAuthorized;
+    case CLAccuracyAuthorizationReducedAccuracy:
+    default:
+      return RNPermissionStatusDenied;
+  }
+}
+
+- (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                 rejecter:(void (__unused ^ _Nonnull)(NSError * _Nonnull))reject {
+  if (![CLLocationManager locationServicesEnabled]) {
+    return resolve(RNPermissionStatusNotAvailable);
+  }
+
+  if (@available(iOS 14.0, *)) {
+    CLLocationManager *locationManager = [CLLocationManager new];
+    return resolve([RNPermissionHandlerLocationFullAccuracy getAccuracyStatus:locationManager]);
+  } else {
+    return resolve(RNPermissionStatusAuthorized);
+  }
+}
+
+- (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+  // It is not possible to request full accuracy permanently within the app.  Either prompt user
+  // to open settings or request temporary full accuracy.
+  return resolve(RNPermissionStatusDenied);
+}
+
+- (void)requestTemporaryWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                            rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                          purposeKey:(NSString * _Nonnull)purposeKey {
+  if (![CLLocationManager locationServicesEnabled]) {
+    return resolve(RNPermissionStatusNotAvailable);
+  }
+
+  if (@available(iOS 14.0, *)) {
+    CLLocationManager *locationManager = [CLLocationManager new];
+    [locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:purposeKey
+                                                                  completion:^(NSError * _Nullable error) {
+      if (error) {
+        return reject(error);
+      }
+      return resolve([RNPermissionHandlerLocationFullAccuracy getAccuracyStatus:locationManager]);
+    }];
+  } else {
+    return resolve(RNPermissionStatusAuthorized);
+  }
+}
+
+@end

--- a/ios/LocationWhenInUse/RNPermissionHandlerLocationWhenInUse.m
+++ b/ios/LocationWhenInUse/RNPermissionHandlerLocationWhenInUse.m
@@ -40,7 +40,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }

--- a/ios/LocationWhenInUse/RNPermissionHandlerLocationWhenInUse.m
+++ b/ios/LocationWhenInUse/RNPermissionHandlerLocationWhenInUse.m
@@ -41,7 +41,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }

--- a/ios/MediaLibrary/RNPermissionHandlerMediaLibrary.m
+++ b/ios/MediaLibrary/RNPermissionHandlerMediaLibrary.m
@@ -36,7 +36,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
 #if TARGET_OS_SIMULATOR
   resolve(RNPermissionStatusNotAvailable);
 #else

--- a/ios/MediaLibrary/RNPermissionHandlerMediaLibrary.m
+++ b/ios/MediaLibrary/RNPermissionHandlerMediaLibrary.m
@@ -35,7 +35,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
 #if TARGET_OS_SIMULATOR
   resolve(RNPermissionStatusNotAvailable);
 #else

--- a/ios/Microphone/RNPermissionHandlerMicrophone.m
+++ b/ios/Microphone/RNPermissionHandlerMicrophone.m
@@ -27,7 +27,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
                            completionHandler:^(__unused BOOL granted) {
     [self checkWithResolver:resolve rejecter:reject];

--- a/ios/Microphone/RNPermissionHandlerMicrophone.m
+++ b/ios/Microphone/RNPermissionHandlerMicrophone.m
@@ -28,7 +28,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
                            completionHandler:^(__unused BOOL granted) {
     [self checkWithResolver:resolve rejecter:reject];

--- a/ios/Motion/RNPermissionHandlerMotion.m
+++ b/ios/Motion/RNPermissionHandlerMotion.m
@@ -42,11 +42,12 @@
     return resolve(RNPermissionStatusNotDetermined);
   }
 
-  [self requestWithResolver:resolve rejecter:reject];
+  [self requestWithResolver:resolve rejecter:reject rationale:nil];
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (![CMMotionActivityManager isActivityAvailable]) {
     return resolve(RNPermissionStatusNotAvailable);
   }

--- a/ios/Motion/RNPermissionHandlerMotion.m
+++ b/ios/Motion/RNPermissionHandlerMotion.m
@@ -42,12 +42,12 @@
     return resolve(RNPermissionStatusNotDetermined);
   }
 
-  [self requestWithResolver:resolve rejecter:reject rationale:nil];
+  [self requestWithResolver:resolve rejecter:reject options:nil];
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (![CMMotionActivityManager isActivityAvailable]) {
     return resolve(RNPermissionStatusNotAvailable);
   }

--- a/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
+++ b/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
@@ -28,7 +28,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   [PHPhotoLibrary requestAuthorization:^(__unused PHAuthorizationStatus status) {
     [self checkWithResolver:resolve rejecter:reject];
   }];

--- a/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
+++ b/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
@@ -27,7 +27,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   [PHPhotoLibrary requestAuthorization:^(__unused PHAuthorizationStatus status) {
     [self checkWithResolver:resolve rejecter:reject];
   }];

--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -76,7 +76,8 @@ typedef enum {
                  rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject;
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject;
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject
+                  rationale:(NSDictionary *_Nullable)rationale;
 
 @end
 

--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -80,7 +80,7 @@ typedef enum {
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus status))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull error))reject
-                  rationale:(NSDictionary *_Nullable)rationale;
+                    options:(NSDictionary *_Nullable)options;
 
 @end
 

--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -48,6 +48,9 @@ typedef NS_ENUM(NSInteger, RNPermission) {
 #if __has_include("RNPermissionHandlerStoreKit.h")
   RNPermissionStoreKit = 15,
 #endif
+#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
+  RNPermissionLocationFullAccuracy = 16,
+#endif
 };
 
 @interface RCTConvert (RNPermission)

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -402,7 +402,7 @@ RCT_REMAP_METHOD(check,
 
 RCT_REMAP_METHOD(request,
                  requestWithPermission:(RNPermission)permission
-                 rationale:(NSDictionary *_Nullable)rationale
+                   options:(NSDictionary *_Nullable)options
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   id<RNPermissionHandler> handler = [self handlerForPermission:permission];
@@ -414,7 +414,7 @@ RCT_REMAP_METHOD(request,
   } rejecter:^(NSError *error) {
     reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
     [self unlockHandler:lockId];
-  } rationale:rationale];
+  } options:options];
 }
 
 RCT_REMAP_METHOD(checkNotifications,

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -388,6 +388,7 @@ RCT_REMAP_METHOD(check,
 
 RCT_REMAP_METHOD(request,
                  requestWithPermission:(RNPermission)permission
+                 rationale:(NSDictionary *_Nullable)rationale
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject) {
   id<RNPermissionHandler> handler = [self handlerForPermission:permission];
@@ -399,7 +400,7 @@ RCT_REMAP_METHOD(request,
   } rejecter:^(NSError *error) {
     reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
     [self unlockHandler:lockId];
-  }];
+  } rationale:rationale];
 }
 
 RCT_REMAP_METHOD(checkNotifications,
@@ -438,26 +439,6 @@ RCT_REMAP_METHOD(requestNotifications,
   } options:options];
 #else
   reject(@"notifications_pod_missing", @"Notifications permission pod is missing", nil);
-#endif
-}
-
-RCT_REMAP_METHOD(requestLocationTemporaryFullAccuracy,
-                 requestLocationTemporaryFullAccuracyWithPurposeKey:(NSString * _Nonnull)purposeKey
-                 resolver:(RCTPromiseResolveBlock)resolve
-                 rejecter:(RCTPromiseRejectBlock)reject) {
-#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
-  RNPermissionHandlerLocationFullAccuracy *handler = [RNPermissionHandlerLocationFullAccuracy new];
-  NSString *lockId = [self lockHandler:(id<RNPermissionHandler>)handler];
-
-  [handler requestTemporaryWithResolver:^(RNPermissionStatus status) {
-    resolve([self stringForStatus:status]);
-    [self unlockHandler:lockId];
-  } rejecter:^(NSError * _Nonnull error) {
-    reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
-    [self unlockHandler:lockId];
-  } purposeKey:purposeKey];
-#else
-  reject(@"location_full_accuracy_pod_missing", @"LocationFullAccuracy permission pod is missing", nil);
 #endif
 }
 

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -22,6 +22,9 @@
 #if __has_include("RNPermissionHandlerLocationWhenInUse.h")
 #import "RNPermissionHandlerLocationWhenInUse.h"
 #endif
+#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
+#import "RNPermissionHandlerLocationFullAccuracy.h"
+#endif
 #if __has_include("RNPermissionHandlerMediaLibrary.h")
 #import "RNPermissionHandlerMediaLibrary.h"
 #endif
@@ -75,6 +78,9 @@ RCT_ENUM_CONVERTER(RNPermission, (@{
 #endif
 #if __has_include("RNPermissionHandlerLocationWhenInUse.h")
   [RNPermissionHandlerLocationWhenInUse handlerUniqueId]: @(RNPermissionLocationWhenInUse),
+#endif
+#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
+  [RNPermissionHandlerLocationFullAccuracy handlerUniqueId]: @(RNPermissionLocationFullAccuracy),
 #endif
 #if __has_include("RNPermissionHandlerMediaLibrary.h")
   [RNPermissionHandlerMediaLibrary handlerUniqueId]: @(RNPermissionMediaLibrary),
@@ -145,6 +151,9 @@ RCT_EXPORT_MODULE();
 #endif
 #if __has_include("RNPermissionHandlerLocationWhenInUse.h")
   [available addObject:[RNPermissionHandlerLocationWhenInUse handlerUniqueId]];
+#endif
+#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
+  [available addObject:[RNPermissionHandlerLocationFullAccuracy handlerUniqueId]];
 #endif
 #if __has_include("RNPermissionHandlerMediaLibrary.h")
   [available addObject:[RNPermissionHandlerMediaLibrary handlerUniqueId]];
@@ -227,6 +236,11 @@ RCT_EXPORT_MODULE();
 #if __has_include("RNPermissionHandlerLocationWhenInUse.h")
     case RNPermissionLocationWhenInUse:
       handler = [RNPermissionHandlerLocationWhenInUse new];
+      break;
+#endif
+#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
+    case RNPermissionLocationFullAccuracy:
+      handler = [RNPermissionHandlerLocationFullAccuracy new];
       break;
 #endif
 #if __has_include("RNPermissionHandlerMediaLibrary.h")
@@ -424,6 +438,26 @@ RCT_REMAP_METHOD(requestNotifications,
   } options:options];
 #else
   reject(@"notifications_pod_missing", @"Notifications permission pod is missing", nil);
+#endif
+}
+
+RCT_REMAP_METHOD(requestLocationTemporaryFullAccuracy,
+                 requestLocationTemporaryFullAccuracyWithPurposeKey:(NSString * _Nonnull)purposeKey
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+#if __has_include("RNPermissionHandlerLocationFullAccuracy.h")
+  RNPermissionHandlerLocationFullAccuracy *handler = [RNPermissionHandlerLocationFullAccuracy new];
+  NSString *lockId = [self lockHandler:(id<RNPermissionHandler>)handler];
+
+  [handler requestTemporaryWithResolver:^(RNPermissionStatus status) {
+    resolve([self stringForStatus:status]);
+    [self unlockHandler:lockId];
+  } rejecter:^(NSError * _Nonnull error) {
+    reject([NSString stringWithFormat:@"%ld", (long)error.code], error.localizedDescription, error);
+    [self unlockHandler:lockId];
+  } purposeKey:purposeKey];
+#else
+  reject(@"location_full_accuracy_pod_missing", @"LocationFullAccuracy permission pod is missing", nil);
 #endif
 }
 

--- a/ios/Reminders/RNPermissionHandlerReminders.m
+++ b/ios/Reminders/RNPermissionHandlerReminders.m
@@ -28,7 +28,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   [[EKEventStore new] requestAccessToEntityType:EKEntityTypeReminder
                                      completion:^(__unused BOOL granted, NSError * _Nullable error) {
     if (error != nil) {

--- a/ios/Reminders/RNPermissionHandlerReminders.m
+++ b/ios/Reminders/RNPermissionHandlerReminders.m
@@ -27,7 +27,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   [[EKEventStore new] requestAccessToEntityType:EKEntityTypeReminder
                                      completion:^(__unused BOOL granted, NSError * _Nullable error) {
     if (error != nil) {

--- a/ios/Siri/RNPermissionHandlerSiri.m
+++ b/ios/Siri/RNPermissionHandlerSiri.m
@@ -31,7 +31,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (@available(iOS 10.0, *)) {
     [INPreferences requestSiriAuthorization:^(__unused INSiriAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/ios/Siri/RNPermissionHandlerSiri.m
+++ b/ios/Siri/RNPermissionHandlerSiri.m
@@ -32,7 +32,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (@available(iOS 10.0, *)) {
     [INPreferences requestSiriAuthorization:^(__unused INSiriAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/ios/SpeechRecognition/RNPermissionHandlerSpeechRecognition.m
+++ b/ios/SpeechRecognition/RNPermissionHandlerSpeechRecognition.m
@@ -31,7 +31,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (@available(iOS 10.0, *)) {
     [SFSpeechRecognizer requestAuthorization:^(__unused SFSpeechRecognizerAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/ios/SpeechRecognition/RNPermissionHandlerSpeechRecognition.m
+++ b/ios/SpeechRecognition/RNPermissionHandlerSpeechRecognition.m
@@ -32,7 +32,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (@available(iOS 10.0, *)) {
     [SFSpeechRecognizer requestAuthorization:^(__unused SFSpeechRecognizerAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/ios/StoreKit/RNPermissionHandlerStoreKit.m
+++ b/ios/StoreKit/RNPermissionHandlerStoreKit.m
@@ -35,7 +35,8 @@
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
-                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
+                  rationale:(NSDictionary *_Nullable)rationale {
   if (@available(iOS 9.3, *)) {
     [SKCloudServiceController requestAuthorization:^(__unused SKCloudServiceAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/ios/StoreKit/RNPermissionHandlerStoreKit.m
+++ b/ios/StoreKit/RNPermissionHandlerStoreKit.m
@@ -36,7 +36,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject
-                  rationale:(NSDictionary *_Nullable)rationale {
+                    options:(NSDictionary *_Nullable)options {
   if (@available(iOS 9.3, *)) {
     [SKCloudServiceController requestAuthorization:^(__unused SKCloudServiceAuthorizationStatus status) {
       [self checkWithResolver:resolve rejecter:reject];

--- a/mock.js
+++ b/mock.js
@@ -39,6 +39,10 @@ export const requestNotifications = jest.fn(async (options) => ({
     }),
 }));
 
+export const requestLocationTemporaryFullAccuracy = jest.fn(
+  async (purposeKey) => RESULTS.GRANTED,
+);
+
 export const checkMultiple = jest.fn(async (permissions) =>
   permissions.reduce((acc, permission) => ({
     ...acc,
@@ -61,6 +65,7 @@ export default {
   request,
   checkNotifications,
   requestNotifications,
+  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/mock.js
+++ b/mock.js
@@ -39,10 +39,6 @@ export const requestNotifications = jest.fn(async (options) => ({
     }),
 }));
 
-export const requestLocationTemporaryFullAccuracy = jest.fn(
-  async (options) => RESULTS.GRANTED,
-);
-
 export const checkMultiple = jest.fn(async (permissions) =>
   permissions.reduce((acc, permission) => ({
     ...acc,
@@ -65,7 +61,6 @@ export default {
   request,
   checkNotifications,
   requestNotifications,
-  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/mock.js
+++ b/mock.js
@@ -40,7 +40,7 @@ export const requestNotifications = jest.fn(async (options) => ({
 }));
 
 export const requestLocationTemporaryFullAccuracy = jest.fn(
-  async (purposeKey) => RESULTS.GRANTED,
+  async (options) => RESULTS.GRANTED,
 );
 
 export const checkMultiple = jest.fn(async (permissions) =>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,7 @@ export const IOS = Object.freeze({
   FACE_ID: 'ios.permission.FACE_ID' as const,
   LOCATION_ALWAYS: 'ios.permission.LOCATION_ALWAYS' as const,
   LOCATION_WHEN_IN_USE: 'ios.permission.LOCATION_WHEN_IN_USE' as const,
+  LOCATION_FULL_ACCURACY: 'ios.permission.LOCATION_FULL_ACCURACY' as const,
   MEDIA_LIBRARY: 'ios.permission.MEDIA_LIBRARY' as const,
   MICROPHONE: 'ios.permission.MICROPHONE' as const,
   MOTION: 'ios.permission.MOTION' as const,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -3,7 +3,7 @@ import {
   NotificationsResponse,
   Permission,
   PermissionStatus,
-  Rationale,
+  RequestOptions,
 } from './types';
 
 export interface Contract {
@@ -11,9 +11,9 @@ export interface Contract {
 
   check(permission: Permission): Promise<PermissionStatus>;
 
-  request(
-    permission: Permission,
-    rationale?: Rationale,
+  request<T extends Permission>(
+    permission: T,
+    options?: RequestOptions<T>,
   ): Promise<PermissionStatus>;
 
   checkNotifications(): Promise<NotificationsResponse>;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -22,9 +22,9 @@ export interface Contract {
     options: NotificationOption[],
   ): Promise<NotificationsResponse>;
 
-  requestLocationTemporaryFullAccuracy(
-    purposeKey: string,
-  ): Promise<PermissionStatus>;
+  requestLocationTemporaryFullAccuracy(options: {
+    purposeKey: string;
+  }): Promise<PermissionStatus>;
 
   checkMultiple<P extends Permission[]>(
     permissions: P,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,13 +1,9 @@
-import {IOS} from './constants';
 import {
-  AndroidPermission,
-  IOSPermission,
   NotificationOption,
   NotificationsResponse,
   Permission,
   PermissionStatus,
-  RationaleAndroid,
-  RationaleFullAccuracyIOS,
+  Rationale,
 } from './types';
 
 export interface Contract {
@@ -16,15 +12,8 @@ export interface Contract {
   check(permission: Permission): Promise<PermissionStatus>;
 
   request(
-    permission: AndroidPermission,
-    rationale?: RationaleAndroid,
-  ): Promise<PermissionStatus>;
-  request(
-    permission: Exclude<IOSPermission, typeof IOS.LOCATION_FULL_ACCURACY>,
-  ): Promise<PermissionStatus>;
-  request(
-    permission: typeof IOS.LOCATION_FULL_ACCURACY,
-    rationale: RationaleFullAccuracyIOS,
+    permission: Permission,
+    rationale?: Rationale,
   ): Promise<PermissionStatus>;
 
   checkNotifications(): Promise<NotificationsResponse>;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -22,6 +22,10 @@ export interface Contract {
     options: NotificationOption[],
   ): Promise<NotificationsResponse>;
 
+  requestLocationTemporaryFullAccuracy(
+    purposeKey: string,
+  ): Promise<PermissionStatus>;
+
   checkMultiple<P extends Permission[]>(
     permissions: P,
   ): Promise<Record<P[number], PermissionStatus>>;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,9 +1,13 @@
+import {IOS} from './constants';
 import {
+  AndroidPermission,
+  IOSPermission,
   NotificationOption,
   NotificationsResponse,
   Permission,
   PermissionStatus,
-  Rationale,
+  RationaleAndroid,
+  RationaleFullAccuracyIOS,
 } from './types';
 
 export interface Contract {
@@ -12,8 +16,15 @@ export interface Contract {
   check(permission: Permission): Promise<PermissionStatus>;
 
   request(
-    permission: Permission,
-    rationale?: Rationale,
+    permission: AndroidPermission,
+    rationale?: RationaleAndroid,
+  ): Promise<PermissionStatus>;
+  request(
+    permission: Exclude<IOSPermission, typeof IOS.LOCATION_FULL_ACCURACY>,
+  ): Promise<PermissionStatus>;
+  request(
+    permission: typeof IOS.LOCATION_FULL_ACCURACY,
+    rationale: RationaleFullAccuracyIOS,
   ): Promise<PermissionStatus>;
 
   checkNotifications(): Promise<NotificationsResponse>;
@@ -21,10 +32,6 @@ export interface Contract {
   requestNotifications(
     options: NotificationOption[],
   ): Promise<NotificationsResponse>;
-
-  requestLocationTemporaryFullAccuracy(options: {
-    purposeKey: string;
-  }): Promise<PermissionStatus>;
 
   checkMultiple<P extends Permission[]>(
     permissions: P,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,6 @@ export const check = module.check;
 export const request = module.request;
 export const checkNotifications = module.checkNotifications;
 export const requestNotifications = module.requestNotifications;
-export const requestLocationTemporaryFullAccuracy =
-  module.requestLocationTemporaryFullAccuracy;
 export const checkMultiple = module.checkMultiple;
 export const requestMultiple = module.requestMultiple;
 
@@ -30,7 +28,6 @@ export default {
   request,
   checkNotifications,
   requestNotifications,
-  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export const check = module.check;
 export const request = module.request;
 export const checkNotifications = module.checkNotifications;
 export const requestNotifications = module.requestNotifications;
+export const requestLocationTemporaryFullAccuracy =
+  module.requestLocationTemporaryFullAccuracy;
 export const checkMultiple = module.checkMultiple;
 export const requestMultiple = module.requestMultiple;
 
@@ -28,6 +30,7 @@ export default {
   request,
   checkNotifications,
   requestNotifications,
+  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/src/module.android.ts
+++ b/src/module.android.ts
@@ -97,6 +97,12 @@ function checkNotifications(): Promise<NotificationsResponse> {
   return RNP.checkNotifications();
 }
 
+export async function requestLocationTemporaryFullAccuracy(
+  _purposeKey: string,
+): Promise<PermissionStatus> {
+  return RESULTS.UNAVAILABLE;
+}
+
 async function checkMultiple<P extends Permission[]>(
   permissions: P,
 ): Promise<Record<P[number], PermissionStatus>> {
@@ -150,6 +156,7 @@ export const module: Contract = {
   request,
   checkNotifications,
   requestNotifications: checkNotifications,
+  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/src/module.android.ts
+++ b/src/module.android.ts
@@ -11,7 +11,7 @@ import {
   Permission,
   PermissionStatus,
   Rationale,
-  RationaleAndroid,
+  RequestOptions,
 } from './types';
 import {uniq} from './utils';
 
@@ -59,17 +59,14 @@ async function check(permission: Permission): Promise<PermissionStatus> {
 
 async function request(
   permission: Permission,
-  rationale?: Rationale,
+  options?: RequestOptions,
 ): Promise<PermissionStatus> {
   if (!RNP.available.includes(permission)) {
     return RESULTS.UNAVAILABLE;
   }
 
   const status = coreStatusToStatus(
-    await Core.request(
-      permission as CorePermission,
-      rationale as RationaleAndroid,
-    ),
+    await Core.request(permission as CorePermission, options as Rationale),
   );
 
   if (status === RESULTS.BLOCKED) {

--- a/src/module.android.ts
+++ b/src/module.android.ts
@@ -3,11 +3,16 @@ import {
   Permission as CorePermission,
   PermissionsAndroid as Core,
   PermissionStatus as CoreStatus,
-  Rationale,
 } from 'react-native';
 import {RESULTS} from './constants';
 import {Contract} from './contract';
-import {NotificationsResponse, Permission, PermissionStatus} from './types';
+import {
+  NotificationsResponse,
+  Permission,
+  PermissionStatus,
+  Rationale,
+  RationaleAndroid,
+} from './types';
 import {uniq} from './utils';
 
 const RNP: {
@@ -61,7 +66,10 @@ async function request(
   }
 
   const status = coreStatusToStatus(
-    await Core.request(permission as CorePermission, rationale),
+    await Core.request(
+      permission as CorePermission,
+      rationale as RationaleAndroid,
+    ),
   );
 
   if (status === RESULTS.BLOCKED) {
@@ -95,12 +103,6 @@ function splitByAvailability<P extends Permission[]>(
 
 function checkNotifications(): Promise<NotificationsResponse> {
   return RNP.checkNotifications();
-}
-
-export async function requestLocationTemporaryFullAccuracy(_options: {}): Promise<
-  PermissionStatus
-> {
-  return RESULTS.UNAVAILABLE;
 }
 
 async function checkMultiple<P extends Permission[]>(
@@ -156,7 +158,6 @@ export const module: Contract = {
   request,
   checkNotifications,
   requestNotifications: checkNotifications,
-  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/src/module.android.ts
+++ b/src/module.android.ts
@@ -97,9 +97,9 @@ function checkNotifications(): Promise<NotificationsResponse> {
   return RNP.checkNotifications();
 }
 
-export async function requestLocationTemporaryFullAccuracy(
-  _purposeKey: string,
-): Promise<PermissionStatus> {
+export async function requestLocationTemporaryFullAccuracy(_options: {}): Promise<
+  PermissionStatus
+> {
   return RESULTS.UNAVAILABLE;
 }
 

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -6,7 +6,7 @@ import {
   NotificationsResponse,
   Permission,
   PermissionStatus,
-  Rationale,
+  RequestOptions,
 } from './types';
 import {uniq} from './utils';
 
@@ -21,7 +21,7 @@ const RNP: {
   check: (permission: Permission) => Promise<PermissionStatus>;
   request: (
     permission: Permission,
-    rationale?: object,
+    options?: object,
   ) => Promise<PermissionStatus>;
 } = NativeModules.RNPermissions;
 
@@ -37,10 +37,10 @@ async function check(permission: Permission): Promise<PermissionStatus> {
 
 async function request(
   permission: Permission,
-  rationale?: Rationale,
+  options?: RequestOptions,
 ): Promise<PermissionStatus> {
   return RNP.available.includes(permission)
-    ? RNP.request(permission, rationale)
+    ? RNP.request(permission, options)
     : RESULTS.UNAVAILABLE;
 }
 

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -6,6 +6,7 @@ import {
   NotificationsResponse,
   Permission,
   PermissionStatus,
+  Rationale,
 } from './types';
 import {uniq} from './utils';
 
@@ -16,12 +17,12 @@ const RNP: {
   requestNotifications: (
     options: NotificationOption[],
   ) => Promise<NotificationsResponse>;
-  requestLocationTemporaryFullAccuracy(
-    purposeKey: string,
-  ): Promise<PermissionStatus>;
   openSettings: () => Promise<true>;
   check: (permission: Permission) => Promise<PermissionStatus>;
-  request: (permission: Permission) => Promise<PermissionStatus>;
+  request: (
+    permission: Permission,
+    rationale?: object,
+  ) => Promise<PermissionStatus>;
 } = NativeModules.RNPermissions;
 
 async function openSettings(): Promise<void> {
@@ -34,9 +35,12 @@ async function check(permission: Permission): Promise<PermissionStatus> {
     : RESULTS.UNAVAILABLE;
 }
 
-async function request(permission: Permission): Promise<PermissionStatus> {
+async function request(
+  permission: Permission,
+  rationale?: Rationale,
+): Promise<PermissionStatus> {
   return RNP.available.includes(permission)
-    ? RNP.request(permission)
+    ? RNP.request(permission, rationale)
     : RESULTS.UNAVAILABLE;
 }
 
@@ -48,12 +52,6 @@ export function requestNotifications(
   options: NotificationOption[],
 ): Promise<NotificationsResponse> {
   return RNP.requestNotifications(options);
-}
-
-export function requestLocationTemporaryFullAccuracy(options: {
-  purposeKey: string;
-}): Promise<PermissionStatus> {
-  return RNP.requestLocationTemporaryFullAccuracy(options.purposeKey);
 }
 
 async function checkMultiple<P extends Permission[]>(
@@ -95,7 +93,6 @@ export const module: Contract = {
   request,
   checkNotifications,
   requestNotifications,
-  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -1,5 +1,5 @@
 import {NativeModules} from 'react-native';
-import {RESULTS, PERMISSIONS} from './constants';
+import {RESULTS} from './constants';
 import {Contract} from './contract';
 import {
   NotificationOption,
@@ -16,6 +16,9 @@ const RNP: {
   requestNotifications: (
     options: NotificationOption[],
   ) => Promise<NotificationsResponse>;
+  requestLocationTemporaryFullAccuracy(
+    purposeKey: string,
+  ): Promise<PermissionStatus>;
   openSettings: () => Promise<true>;
   check: (permission: Permission) => Promise<PermissionStatus>;
   request: (permission: Permission) => Promise<PermissionStatus>;
@@ -45,6 +48,12 @@ export function requestNotifications(
   options: NotificationOption[],
 ): Promise<NotificationsResponse> {
   return RNP.requestNotifications(options);
+}
+
+export function requestLocationTemporaryFullAccuracy(
+  purposeKey: string,
+): Promise<PermissionStatus> {
+  return RNP.requestLocationTemporaryFullAccuracy(purposeKey);
 }
 
 async function checkMultiple<P extends Permission[]>(
@@ -86,6 +95,7 @@ export const module: Contract = {
   request,
   checkNotifications,
   requestNotifications,
+  requestLocationTemporaryFullAccuracy,
   checkMultiple,
   requestMultiple,
 };

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -50,10 +50,10 @@ export function requestNotifications(
   return RNP.requestNotifications(options);
 }
 
-export function requestLocationTemporaryFullAccuracy(
-  purposeKey: string,
-): Promise<PermissionStatus> {
-  return RNP.requestLocationTemporaryFullAccuracy(purposeKey);
+export function requestLocationTemporaryFullAccuracy(options: {
+  purposeKey: string;
+}): Promise<PermissionStatus> {
+  return RNP.requestLocationTemporaryFullAccuracy(options.purposeKey);
 }
 
 async function checkMultiple<P extends Permission[]>(

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,7 +25,6 @@ export const module: Contract = {
   request: check,
   checkNotifications,
   requestNotifications: checkNotifications,
-  requestLocationTemporaryFullAccuracy: check,
   checkMultiple,
   requestMultiple: checkMultiple,
 };

--- a/src/module.ts
+++ b/src/module.ts
@@ -25,6 +25,7 @@ export const module: Contract = {
   request: check,
   checkNotifications,
   requestNotifications: checkNotifications,
+  requestLocationTemporaryFullAccuracy: check,
   checkMultiple,
   requestMultiple: checkMultiple,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
 import {ANDROID, IOS, RESULTS} from './constants';
-import {Rationale as RNRationalAndroid} from 'react-native';
+import {Rationale as RNRationaleAndroid} from 'react-native';
 
 type Values<T extends object> = T[keyof T];
 
-export type RationaleAndroid = RNRationalAndroid;
+export type RationaleAndroid = RNRationaleAndroid;
 export interface RationaleFullAccuracyIOS {
   temporaryPurposeKey: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,13 @@
 import {ANDROID, IOS, RESULTS} from './constants';
+import {Rationale as RNRationalAndroid} from 'react-native';
 
 type Values<T extends object> = T[keyof T];
 
-export {Rationale} from 'react-native';
+export type RationaleAndroid = RNRationalAndroid;
+export interface RationaleFullAccuracyIOS {
+  temporaryPurposeKey: string;
+}
+export type Rationale = RationaleAndroid | RationaleFullAccuracyIOS;
 
 export type AndroidPermission = Values<typeof ANDROID>;
 export type IOSPermission = Values<typeof IOS>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,24 @@
-import {ANDROID, IOS, RESULTS} from './constants';
-import {Rationale as RNRationaleAndroid} from 'react-native';
+import {ANDROID, IOS, PERMISSIONS, RESULTS} from './constants';
+import {Rationale} from 'react-native';
+
+export {Rationale} from 'react-native';
 
 type Values<T extends object> = T[keyof T];
-
-export type RationaleAndroid = RNRationaleAndroid;
-export interface RationaleFullAccuracyIOS {
-  temporaryPurposeKey: string;
-}
-export type Rationale = RationaleAndroid | RationaleFullAccuracyIOS;
 
 export type AndroidPermission = Values<typeof ANDROID>;
 export type IOSPermission = Values<typeof IOS>;
 export type Permission = AndroidPermission | IOSPermission;
 
 export type PermissionStatus = Values<typeof RESULTS>;
+
+export interface FullAccuracyOptionsIOS {
+  temporaryPurposeKey: string;
+}
+export type RequestOptions<
+  T extends Permission = Permission
+> = T extends typeof PERMISSIONS.IOS.LOCATION_FULL_ACCURACY
+  ? FullAccuracyOptionsIOS
+  : Rationale;
 
 export type NotificationOption =
   | 'alert'


### PR DESCRIPTION
Adds a LocationFullAccuracy pod for checking and requesting (temporary) full accuracy on iOS 14.  Addresses issue #489.

Updates the `request` rationale to require a `temporaryPurposeKey` for this permission.  I experimented with adding a separate function for this temporary permission, but I think this solution is more elegant.  Feedback welcome.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Test on an iOS 14 beta 3 device in the example app with combinations of when-in-use/background and full/reduced accuracy permissions.

### What's required for testing (prerequisites)?

- iOS 14 beta 3
- Xcode Version 12.0 beta 3

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
