### PR TITLE
Support iOS 14 photo permission API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ target 'YourAwesomeProject' do
   pod 'Permission-Motion', :path => "#{permissions_path}/Motion.podspec"
   pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications.podspec"
   pod 'Permission-PhotoLibrary', :path => "#{permissions_path}/PhotoLibrary.podspec"
+  pod 'Permission-PhotoLibraryAddOnly', :path => "#{permissions_path}/PhotoLibraryAddOnly.podspec"
   pod 'Permission-Reminders', :path => "#{permissions_path}/Reminders.podspec"
   pod 'Permission-Siri', :path => "#{permissions_path}/Siri.podspec"
   pod 'Permission-SpeechRecognition', :path => "#{permissions_path}/SpeechRecognition.podspec"
@@ -93,6 +94,8 @@ Then update your `Info.plist` with wanted permissions usage descriptions:
   <string>YOUR TEXT</string>
   <key>NSPhotoLibraryUsageDescription</key>
   <string>YOUR TEXT</string>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+	<string>YOUR TEXT</string>
   <key>NSRemindersUsageDescription</key>
   <string>YOUR TEXT</string>
   <key>NSSpeechRecognitionUsageDescription</key>
@@ -391,6 +394,7 @@ PERMISSIONS.IOS.MEDIA_LIBRARY;
 PERMISSIONS.IOS.MICROPHONE;
 PERMISSIONS.IOS.MOTION;
 PERMISSIONS.IOS.PHOTO_LIBRARY;
+PERMISSIONS.IOS.PHOTO_LIBRARY_ADD_ONLY;
 PERMISSIONS.IOS.REMINDERS;
 PERMISSIONS.IOS.SIRI;
 PERMISSIONS.IOS.SPEECH_RECOGNITION;
@@ -407,12 +411,18 @@ Permission checks and requests resolve into one of these statuses:
 | `RESULTS.DENIED`      | The permission has not been requested / is denied but requestable |
 | `RESULTS.GRANTED`     | The permission is granted                                         |
 | `RESULTS.BLOCKED`     | The permission is denied and not requestable anymore              |
+| `RESULTS.LIMITED`     | The permission is granted but with limitations                    |
 
 ### Methods
 
 ```ts
 // type used in usage examples
-type PermissionStatus = 'unavailable' | 'denied' | 'blocked' | 'granted';
+type PermissionStatus =
+  | 'unavailable'
+  | 'denied'
+  | 'blocked'
+  | 'granted'
+  | 'limited';
 ```
 
 #### check
@@ -618,6 +628,24 @@ function openSettings(): Promise<void>;
 import {openSettings} from 'react-native-permissions';
 
 openSettings().catch(() => console.warn('cannot open settings'));
+```
+
+---
+
+#### presentLimitedLibraryPicker
+
+On iOS, open a picker to update the photo selection when limited permissions are given. This is a no-op on Android, and when full permissions are given.
+
+```ts
+function presentLimitedLibraryPicker(): Promise<void>;
+```
+
+```js
+import {presentLimitedLibraryPicker} from 'react-native-permissions';
+
+presentLimitedLibraryPicker().catch(() =>
+  console.warn('cannot open presentLimitedLibraryPicker'),
+);
 ```
 
 ## Migrating from v1.x.x

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -28,6 +28,7 @@ const colors: {[key: string]: string} = {
   denied: '#ff9800',
   granted: '#43a047',
   blocked: '#e53935',
+  limited: '#ffdd00',
 };
 
 const icons: {[key: string]: string} = {
@@ -35,6 +36,7 @@ const icons: {[key: string]: string} = {
   denied: 'alert-circle',
   granted: 'check-circle',
   blocked: 'close-circle',
+  limited: 'check-circle-outline',
 };
 
 const PermissionRow = ({
@@ -115,6 +117,12 @@ export default class App extends React.Component<{}, State> {
             icon="settings"
             onPress={() => {
               RNPermissions.openSettings();
+            }}
+          />
+          <Appbar.Action
+            icon="image-multiple"
+            onPress={() => {
+              RNPermissions.presentLimitedLibraryPicker();
             }}
           />
         </Appbar.Header>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -107,6 +107,7 @@ target 'RNPermissionsExample' do
   pod 'Permission-Motion', :path => "#{permissions_path}/Motion.podspec"
   pod 'Permission-Notifications', :path => "#{permissions_path}/Notifications.podspec"
   pod 'Permission-PhotoLibrary', :path => "#{permissions_path}/PhotoLibrary.podspec"
+  pod 'Permission-PhotoLibraryAddOnly', :path => "#{permissions_path}/PhotoLibraryAddOnly.podspec"
   pod 'Permission-Reminders', :path => "#{permissions_path}/Reminders.podspec"
   # pod 'Permission-Siri', :path => "#{permissions_path}/Siri.podspec"
   pod 'Permission-SpeechRecognition', :path => "#{permissions_path}/SpeechRecognition.podspec"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -96,6 +96,8 @@ PODS:
     - RNPermissions
   - Permission-PhotoLibrary (2.2.0):
     - RNPermissions
+  - Permission-PhotoLibraryAddOnly (2.2.0):
+    - RNPermissions
   - Permission-Reminders (2.2.0):
     - RNPermissions
   - Permission-SpeechRecognition (2.2.0):
@@ -370,6 +372,7 @@ DEPENDENCIES:
   - Permission-Motion (from `../node_modules/react-native-permissions/ios/Motion.podspec`)
   - Permission-Notifications (from `../node_modules/react-native-permissions/ios/Notifications.podspec`)
   - Permission-PhotoLibrary (from `../node_modules/react-native-permissions/ios/PhotoLibrary.podspec`)
+  - Permission-PhotoLibraryAddOnly (from `../node_modules/react-native-permissions/ios/PhotoLibraryAddOnly.podspec`)
   - Permission-Reminders (from `../node_modules/react-native-permissions/ios/Reminders.podspec`)
   - Permission-SpeechRecognition (from `../node_modules/react-native-permissions/ios/SpeechRecognition.podspec`)
   - Permission-StoreKit (from `../node_modules/react-native-permissions/ios/StoreKit.podspec`)
@@ -451,6 +454,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-permissions/ios/Notifications.podspec"
   Permission-PhotoLibrary:
     :path: "../node_modules/react-native-permissions/ios/PhotoLibrary.podspec"
+  Permission-PhotoLibraryAddOnly:
+    :path: "../node_modules/react-native-permissions/ios/PhotoLibraryAddOnly.podspec"
   Permission-Reminders:
     :path: "../node_modules/react-native-permissions/ios/Reminders.podspec"
   Permission-SpeechRecognition:
@@ -531,7 +536,8 @@ SPEC CHECKSUMS:
   Permission-Microphone: 06462b9d979ada12095bcff8d5ee1aeeeaf20b5d
   Permission-Motion: b8f1f0e7baf8fb136fc54aabf6a8669e95265d16
   Permission-Notifications: 572d4e94121e57dbecc71a0933abd8ed61108e92
-  Permission-PhotoLibrary: e3ff899f87a3eda29427c142ca93837e8802d228
+  Permission-PhotoLibrary: e7419100010711b9c1cf002c1483653d66e6c246
+  Permission-PhotoLibraryAddOnly: a8f8e696158be0d7652dc14a3ce8f1d9d738e7ab
   Permission-Reminders: 82dfcc66d1afdaef20a0084350753c3ff2691e4a
   Permission-SpeechRecognition: 0dc3e7a65fa38beb9d249cd37ef1b1565f72a494
   Permission-StoreKit: 0fc596a9c7d2c3fbebfd4b1c89222db3ce94eba2
@@ -559,6 +565,6 @@ SPEC CHECKSUMS:
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 33d4013cd5154539040dffe614d959a536bc61f4
+PODFILE CHECKSUM: 8f91a3a16ccf05cf62965b5febfce149cb72da42
 
 COCOAPODS: 1.9.3

--- a/example/ios/RNPermissionsExample/Info.plist
+++ b/example/ios/RNPermissionsExample/Info.plist
@@ -61,6 +61,8 @@
 	<string>Let me use the microphone</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Let me use your motion data</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Let me add photos</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Let me use your photo library</string>
 	<key>NSRemindersUsageDescription</key>

--- a/ios/PhotoLibrary.podspec
+++ b/ios/PhotoLibrary.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
 
   s.source                    = { :git => package["repository"]["url"], :tag => s.version }
   s.source_files              = "PhotoLibrary/*.{h,m}"
+  s.frameworks                = "PhotosUI"
 end

--- a/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.h
+++ b/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.h
@@ -2,4 +2,6 @@
 
 @interface RNPermissionHandlerPhotoLibrary : NSObject<RNPermissionHandler>
 
+- (void)presentLimitedLibraryPickerFromViewController API_AVAILABLE(ios(14));
+
 @end

--- a/ios/PhotoLibraryAddOnly.podspec
+++ b/ios/PhotoLibraryAddOnly.podspec
@@ -1,0 +1,21 @@
+require 'json'
+package = JSON.parse(File.read('../package.json'))
+
+Pod::Spec.new do |s|
+  s.name                      = "Permission-PhotoLibraryAddOnly"
+  s.dependency                  "RNPermissions"
+
+  s.version                   = package["version"]
+  s.license                   = package["license"]
+  s.summary                   = package["description"]
+  s.authors                   = package["author"]
+  s.homepage                  = package["homepage"]
+
+  s.platform                  = :ios, "9.0"
+  s.ios.deployment_target     = "9.0"
+  s.tvos.deployment_target    = "11.0"
+  s.requires_arc              = true
+
+  s.source                    = { :git => package["repository"]["url"], :tag => s.version }
+  s.source_files              = "PhotoLibraryAddOnly/*.{h,m}"
+end

--- a/ios/PhotoLibraryAddOnly/RNPermissionHandlerPhotoLibraryAddOnly.h
+++ b/ios/PhotoLibraryAddOnly/RNPermissionHandlerPhotoLibraryAddOnly.h
@@ -1,0 +1,5 @@
+#import "RNPermissions.h"
+
+@interface RNPermissionHandlerPhotoLibraryAddOnly : NSObject<RNPermissionHandler>
+
+@end

--- a/ios/PhotoLibraryAddOnly/RNPermissionHandlerPhotoLibraryAddOnly.m
+++ b/ios/PhotoLibraryAddOnly/RNPermissionHandlerPhotoLibraryAddOnly.m
@@ -1,0 +1,53 @@
+#import "RNPermissionHandlerPhotoLibraryAddOnly.h"
+
+@import Photos;
+
+@implementation RNPermissionHandlerPhotoLibraryAddOnly
+
++ (NSArray<NSString *> * _Nonnull)usageDescriptionKeys {
+  return @[@"NSPhotoLibraryUsageDescription"];
+}
+
++ (NSString * _Nonnull)handlerUniqueId {
+  return @"ios.permission.PHOTO_LIBRARY_ADD_ONLY";
+}
+
+- (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                 rejecter:(void (__unused ^ _Nonnull)(NSError * _Nonnull))reject {
+  PHAuthorizationStatus status;
+  if (@available(iOS 14.0, *)) {
+    status = [PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelAddOnly];
+  } else {
+    status = [PHPhotoLibrary authorizationStatus];
+  }
+  
+  switch (status) {
+    case PHAuthorizationStatusNotDetermined:
+      return resolve(RNPermissionStatusNotDetermined);
+    case PHAuthorizationStatusRestricted:
+      return resolve(RNPermissionStatusRestricted);
+    case PHAuthorizationStatusDenied:
+      return resolve(RNPermissionStatusDenied);
+    case PHAuthorizationStatusAuthorized:
+      return resolve(RNPermissionStatusAuthorized);
+    case PHAuthorizationStatusLimited:
+      return resolve(RNPermissionStatusLimited);
+  }
+}
+
+- (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
+                   rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
+  
+  if (@available(iOS 14.0, *)) {
+    [PHPhotoLibrary requestAuthorizationForAccessLevel:PHAccessLevelAddOnly handler:^(__unused PHAuthorizationStatus status) {
+      [self checkWithResolver:resolve rejecter:reject];
+    }];
+    return;
+  }
+  
+  [PHPhotoLibrary requestAuthorization:^(__unused PHAuthorizationStatus status) {
+    [self checkWithResolver:resolve rejecter:reject];
+  }];
+}
+
+@end

--- a/ios/RNPermissions.h
+++ b/ios/RNPermissions.h
@@ -51,6 +51,9 @@ typedef NS_ENUM(NSInteger, RNPermission) {
 #if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
   RNPermissionAppTrackingTransparency = 16,
 #endif
+#if __has_include("RNPermissionHandlerPhotoLibraryAddOnly.h")
+  RNPermissionAppPhotoLibraryAddOnly = 17,
+#endif
 };
 
 @interface RCTConvert (RNPermission)
@@ -62,6 +65,7 @@ typedef enum {
   RNPermissionStatusRestricted = 2,
   RNPermissionStatusDenied = 3,
   RNPermissionStatusAuthorized = 4,
+  RNPermissionStatusLimited = 5,
 } RNPermissionStatus;
 
 @protocol RNPermissionHandler <NSObject>

--- a/ios/RNPermissions.m
+++ b/ios/RNPermissions.m
@@ -52,6 +52,9 @@
 #if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
 #import "RNPermissionHandlerAppTrackingTransparency.h"
 #endif
+#if __has_include("RNPermissionHandlerPhotoLibraryAddOnly.h")
+#import "RNPermissionHandlerPhotoLibraryAddOnly.h"
+#endif
 
 static NSString* SETTING_KEY = @"@RNPermissions:Requested";
 
@@ -105,6 +108,9 @@ RCT_ENUM_CONVERTER(RNPermission, (@{
 #endif
 #if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
   [RNPermissionHandlerAppTrackingTransparency handlerUniqueId]: @(RNPermissionAppTrackingTransparency),
+#endif
+#if __has_include("RNPermissionHandlerPhotoLibraryAddOnly.h")
+  [RNPermissionHandlerPhotoLibraryAddOnly handlerUniqueId]: @(RNPermissionAppPhotoLibraryAddOnly),
 #endif
 }), RNPermissionUnknown, integerValue);
 
@@ -181,6 +187,9 @@ RCT_EXPORT_MODULE();
 #endif
 #if __has_include("RNPermissionHandlerAppTrackingTransparency.h")
   [available addObject:[RNPermissionHandlerAppTrackingTransparency handlerUniqueId]];
+#endif
+#if __has_include("RNPermissionHandlerPhotoLibraryAddOnly.h")
+  [available addObject:[RNPermissionHandlerPhotoLibraryAddOnly handlerUniqueId]];
 #endif
 
 #if RCT_DEV
@@ -283,6 +292,11 @@ RCT_EXPORT_MODULE();
       handler = [RNPermissionHandlerAppTrackingTransparency new];
       break;
 #endif
+#if __has_include("RNPermissionHandlerPhotoLibraryAddOnly.h")
+    case RNPermissionAppPhotoLibraryAddOnly:
+      handler = [RNPermissionHandlerPhotoLibraryAddOnly new];
+      break;
+#endif
     case RNPermissionUnknown:
       break; // RCTConvert prevents this case
   }
@@ -310,6 +324,8 @@ RCT_EXPORT_MODULE();
       return @"blocked";
     case RNPermissionStatusAuthorized:
       return @"granted";
+    case RNPermissionStatusLimited:
+      return @"limited";
   }
 }
 
@@ -440,5 +456,22 @@ RCT_REMAP_METHOD(requestNotifications,
   reject(@"notifications_pod_missing", @"Notifications permission pod is missing", nil);
 #endif
 }
+
+RCT_REMAP_METHOD(presentLimitedLibraryPicker,
+                 presentLimitedLibraryPickerWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject) {
+#if __has_include("RNPermissionHandlerPhotoLibrary.h")
+  if (@available(iOS 14.0, *)) {
+    RNPermissionHandlerPhotoLibrary *handler = [RNPermissionHandlerPhotoLibrary new];
+    [handler presentLimitedLibraryPickerFromViewController];
+    resolve(@true);
+  } else {
+    reject(@"cannot_open_limited_picker", @"Limited picker is only available on iOS 14 or higher.", nil);
+  }
+#else
+  reject(@"photos_pod_missing", @"Photo permission pod is missing", nil);
+#endif
+}
+
 
 @end

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,7 @@ export const IOS = Object.freeze({
   MICROPHONE: 'ios.permission.MICROPHONE' as const,
   MOTION: 'ios.permission.MOTION' as const,
   PHOTO_LIBRARY: 'ios.permission.PHOTO_LIBRARY' as const,
+  PHOTO_LIBRARY_ADD_ONLY: 'ios.permission.PHOTO_LIBRARY_ADD_ONLY' as const,
   REMINDERS: 'ios.permission.REMINDERS' as const,
   SIRI: 'ios.permission.SIRI' as const,
   SPEECH_RECOGNITION: 'ios.permission.SPEECH_RECOGNITION' as const,
@@ -56,4 +57,5 @@ export const RESULTS = Object.freeze({
   DENIED: 'denied' as const,
   BLOCKED: 'blocked' as const,
   GRANTED: 'granted' as const,
+  LIMITED: 'limited' as const,
 });

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -9,6 +9,8 @@ import {
 export interface Contract {
   openSettings(): Promise<void>;
 
+  presentLimitedLibraryPicker(): Promise<void>;
+
   check(permission: Permission): Promise<PermissionStatus>;
 
   request(

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export const checkNotifications = module.checkNotifications;
 export const requestNotifications = module.requestNotifications;
 export const checkMultiple = module.checkMultiple;
 export const requestMultiple = module.requestMultiple;
+export const presentLimitedLibraryPicker = module.presentLimitedLibraryPicker;
 
 export default {
   PERMISSIONS,
@@ -30,4 +31,5 @@ export default {
   requestNotifications,
   checkMultiple,
   requestMultiple,
+  presentLimitedLibraryPicker,
 };

--- a/src/module.android.ts
+++ b/src/module.android.ts
@@ -34,6 +34,10 @@ function coreStatusToStatus(status: CoreStatus): PermissionStatus {
   }
 }
 
+async function presentLimitedLibraryPicker(): Promise<void> {
+  return;
+}
+
 async function openSettings(): Promise<void> {
   await RNP.openSettings();
 }
@@ -152,4 +156,5 @@ export const module: Contract = {
   requestNotifications: checkNotifications,
   checkMultiple,
   requestMultiple,
+  presentLimitedLibraryPicker,
 };

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -17,12 +17,17 @@ const RNP: {
     options: NotificationOption[],
   ) => Promise<NotificationsResponse>;
   openSettings: () => Promise<true>;
+  presentLimitedLibraryPicker: () => Promise<true>;
   check: (permission: Permission) => Promise<PermissionStatus>;
   request: (permission: Permission) => Promise<PermissionStatus>;
 } = NativeModules.RNPermissions;
 
 async function openSettings(): Promise<void> {
   await RNP.openSettings();
+}
+
+async function presentLimitedLibraryPicker(): Promise<void> {
+  await RNP.presentLimitedLibraryPicker();
 }
 
 async function check(permission: Permission): Promise<PermissionStatus> {
@@ -88,4 +93,5 @@ export const module: Contract = {
   requestNotifications,
   checkMultiple,
   requestMultiple,
+  presentLimitedLibraryPicker,
 };

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,6 +21,7 @@ async function checkMultiple<P extends Permission[]>(
 
 export const module: Contract = {
   openSettings: Promise.reject,
+  presentLimitedLibraryPicker: Promise.reject,
   check,
   request: check,
   checkNotifications,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
iOS 14 comes with some photo permission API changes that impact behavior for apps using this library.
→ Permissions are now split in “ReadWrite” and “AddOnly” permissions, so read permission is not always necessary.
→ Users can now grant “limited” permission, allowing them to pick which photos to share.

I’ve implemented both of these changes in the following way:
→ Updated the PhotoLibrary pod to make use of the new API, asking for “ReadWrite” permission (which is the old behavior)
→ Added PhotoLibraryAddOnly pod which asks AddOnly permission, (it behaves like a subset of ReadWrite, if ReadWrite is granted AddOnly is also granted)
→ When limited permission is given users can use a new method `presentLimitedLibraryPicker` to summon the limited selection picker to update the selection. This is a no-op if users give access to their full library. By making it a separate method library users are flexible when to show it (i.e. make it available via a button so users can update their shared photo subset at any time)

Impacts only iOS.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
