### PR TITLE
Fix LimitedLibraryPicker not popping up. 

### DIFF
--- a/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
+++ b/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
@@ -1,4 +1,5 @@
 #import "RNPermissionHandlerPhotoLibrary.h"
+#import <React/RCTUtils.h>
 
 @import Photos;
 @import PhotosUI;
@@ -57,15 +58,7 @@
       return reject(@"cannot_open_limited_picker", @"Photo library permission isn't limited", nil);
     }
     
-    UIViewController* topViewController = [[UIApplication sharedApplication].keyWindow rootViewController];
-    UIViewController* presentedViewController = topViewController.presentedViewController;
-
-    while (presentedViewController = topViewController.presentedViewController) {
-      topViewController = presentedViewController;
-      presentedViewController = topViewController.presentedViewController;
-    }
-
-    UIViewController* rootViewController = [[UIApplication sharedApplication].keyWindow rootViewController];
+    UIViewController *topViewController = RCTPresentedViewController();
     [[PHPhotoLibrary sharedPhotoLibrary] presentLimitedLibraryPickerFromViewController:topViewController];
 
     resolve(@(true));

--- a/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
+++ b/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
@@ -66,7 +66,7 @@
     }
 
     UIViewController* rootViewController = [[UIApplication sharedApplication].keyWindow rootViewController];
-    [[PHPhotoLibrary sharedPhotoLibrary] presentLimitedLibraryPickerFromViewController:rootViewController];
+    [[PHPhotoLibrary sharedPhotoLibrary] presentLimitedLibraryPickerFromViewController:topViewController];
 
     resolve(@(true));
   } else {

--- a/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
+++ b/ios/PhotoLibrary/RNPermissionHandlerPhotoLibrary.m
@@ -56,6 +56,14 @@
     if ([PHPhotoLibrary authorizationStatusForAccessLevel:PHAccessLevelReadWrite] != PHAuthorizationStatusLimited) {
       return reject(@"cannot_open_limited_picker", @"Photo library permission isn't limited", nil);
     }
+    
+    UIViewController* topViewController = [[UIApplication sharedApplication].keyWindow rootViewController];
+    UIViewController* presentedViewController = topViewController.presentedViewController;
+
+    while (presentedViewController = topViewController.presentedViewController) {
+      topViewController = presentedViewController;
+      presentedViewController = topViewController.presentedViewController;
+    }
 
     UIViewController* rootViewController = [[UIApplication sharedApplication].keyWindow rootViewController];
     [[PHPhotoLibrary sharedPhotoLibrary] presentLimitedLibraryPickerFromViewController:rootViewController];


### PR DESCRIPTION
# Summary

If you have multiple ViewControllers nested, the prompt for the LimitedLibraryPicker will not prompt on the right viewcontroller, which makes nothing actually happen.

Added a quick cycler to go through the tree until it finds the top most view controller.

## Test Plan

I have run this on many different instances to make sure the code is still solid. So far I have found no issues with this small code snippet. 

### What's required for testing (prerequisites)?

None required. Just have an app with react-native-permissions installed. 

### What are the steps to reproduce (after prerequisites)?

Go multiple viewcontrollers down within an app and try to call the LimitedLibraryPicker. On 3.0.0 this does not work. On the current version of the app is does. 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    -iOS Only Bug-   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ X] I have tested this on a device and a simulator
- [ X] I added the documentation in `README.md`
- [X ] I mentioned this change in `CHANGELOG.md`
- [ X] I updated the typed files (TS and Flow)
- [ X] I added a sample use of the API in the example project (`example/App.js`)

This is a very simple commit. The above are not necassary. Not much at all has changed. 
