### PR TITLE
Fix/open settings typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ requestMultiple([PERMISSIONS.IOS.CAMERA, PERMISSIONS.IOS.FACE_ID]).then(
 Open application settings.
 
 ```ts
-function openSettings(): Promise<void>;
+function openSettings(): Promise<true>;
 ```
 
 ```js

--- a/mock.js
+++ b/mock.js
@@ -1,7 +1,7 @@
 const {PERMISSIONS, RESULTS} = require('./lib/commonjs/constants');
 export {PERMISSIONS, RESULTS};
 
-export const openSettings = jest.fn(async () => {});
+export const openSettings = jest.fn(async () => true);
 export const check = jest.fn(async (permission) => RESULTS.GRANTED);
 export const request = jest.fn(async (permission) => RESULTS.GRANTED);
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -7,7 +7,7 @@ import {
 } from './types';
 
 export interface Contract {
-  openSettings(): Promise<void>;
+  openSettings(): Promise<true>;
 
   check(permission: Permission): Promise<PermissionStatus>;
 

--- a/src/module.android.ts
+++ b/src/module.android.ts
@@ -34,8 +34,8 @@ function coreStatusToStatus(status: CoreStatus): PermissionStatus {
   }
 }
 
-async function openSettings(): Promise<void> {
-  await RNP.openSettings();
+function openSettings() {
+  return RNP.openSettings();
 }
 
 async function check(permission: Permission): Promise<PermissionStatus> {

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -21,8 +21,8 @@ const RNP: {
   request: (permission: Permission) => Promise<PermissionStatus>;
 } = NativeModules.RNPermissions;
 
-async function openSettings(): Promise<void> {
-  await RNP.openSettings();
+function openSettings() {
+  return RNP.openSettings();
 }
 
 async function check(permission: Permission): Promise<PermissionStatus> {

--- a/src/module.ios.ts
+++ b/src/module.ios.ts
@@ -1,5 +1,5 @@
 import {NativeModules} from 'react-native';
-import {RESULTS, PERMISSIONS} from './constants';
+import {RESULTS} from './constants';
 import {Contract} from './contract';
 import {
   NotificationOption,

--- a/src/module.windows.ts
+++ b/src/module.windows.ts
@@ -4,13 +4,13 @@ import {NotificationsResponse, Permission, PermissionStatus} from './types';
 import {uniq} from './utils';
 
 const RNP: {
-  OpenSettings: () => Promise<void>;
+  OpenSettings: () => Promise<true>;
   CheckNotifications: () => Promise<PermissionStatus>;
   Check: (permission: Permission) => Promise<PermissionStatus>;
   Request: (permission: Permission) => Promise<PermissionStatus>;
 } = NativeModules.RNPermissions;
 
-async function openSettings(): Promise<void> {
+function openSettings() {
   return RNP.OpenSettings();
 }
 

--- a/windows/RNPermissions/RNPermissions.cpp
+++ b/windows/RNPermissions/RNPermissions.cpp
@@ -12,12 +12,12 @@ inline void RNPermissions::RNPermissions::Init(React::ReactContext const& reactC
   m_reactContext = reactContext;
 }
 
-inline void RNPermissions::RNPermissions::OpenSettings(React::ReactPromise<void>&& promise) noexcept {
+inline void RNPermissions::RNPermissions::OpenSettings(React::ReactPromise<std::true_type>&& promise) noexcept {
   m_reactContext.UIDispatcher().Post([promise]() {
     Launcher::LaunchUriAsync(Uri(L"ms-settings:appsfeatures-app"))
       .Completed([promise](const auto&, const auto& status) {
         if (status == AsyncStatus::Completed) {
-          promise.Resolve();
+          promise.Resolve(true);
         }
         else {
           promise.Reject("Failure");

--- a/windows/RNPermissions/RNPermissions.h
+++ b/windows/RNPermissions/RNPermissions.h
@@ -13,7 +13,7 @@ namespace RNPermissions
     void Init(React::ReactContext const& reactContext) noexcept;
 
     REACT_METHOD(OpenSettings);
-    void OpenSettings(React::ReactPromise<void>&& promise) noexcept;
+    void OpenSettings(React::ReactPromise<std::true_type>&& promise) noexcept;
 
     REACT_METHOD(CheckNotifications);
     void CheckNotifications(React::ReactPromise<std::string>&& promise) noexcept;


### PR DESCRIPTION
# Summary

* What issues does the pull request solve?
openSettings typing using a `void` return type causes an unexpected behavior/usage when consumed through an observable: 
  - an observable never emits & directly completes if consuming a promise returning `void`
  - it emits `true` then completes if consuming a promise returning `true` (boolean)

* How did you implement the solution?
fixed typings in global TS contract & ios/android/windows modules + changed the return type of the C++ windows implementation. But without much C++ knowledge and no windows machine to check ! please confirm or suggest a valid type for `boolean true` in `RNPermissions.h` & .cpp.

* What areas of the library does it impact?
ios, android and windows typings + windows implementation of `openSettings()`.

/!\ I simplified the signature of openSettings() in module.ios.ts & module.android.ts, please review & confirm if it suits the coding rules of this project.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅    |
| Windows |   ?    |

## Checklist

- [-] I have tested this on a device and a simulator
-> only partially, I don't have a windows machine.
- [X] I added the documentation in `README.md`
- [X] I updated the typed files (TS and Flow)
