### PR TITLE
Add Xcode version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ For Windows only builds 18362 and later are supported.
 
 ## Support
 
-| version | react-native version |
-| ------- | -------------------- |
-| 3.0.0+  | 0.63.0+              |
+| version | react-native version | Xcode version |
+| ------- | -------------------- | ------------- |
+| 3.0.0+  | 0.63.0+              | 12+           |
 
 ## Setup
 


### PR DESCRIPTION
As mentioned in https://github.com/zoontek/react-native-permissions/issues/548, v3.0.0 requires Xcode 12.