### PR TITLE
Fix issue on Android 8, 9, 10 that made checkNotifications always granted

### DIFF
--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
@@ -3,6 +3,8 @@ package com.zoontek.rnpermissions;
 import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -30,6 +32,7 @@ import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @ReactModule(name = RNPermissionsModule.MODULE_NAME)
 public class RNPermissionsModule extends ReactContextBaseJavaModule implements PermissionListener {
@@ -145,10 +148,27 @@ public class RNPermissionsModule extends ReactContextBaseJavaModule implements P
     }
   }
 
+  private boolean areNotificationsEnabled() {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        NotificationManager manager = (NotificationManager) getReactApplicationContext().getSystemService(Context.NOTIFICATION_SERVICE);
+        if (!manager.areNotificationsEnabled()) {
+          return false;
+        }
+        List<NotificationChannel> channels = manager.getNotificationChannels();
+        for (NotificationChannel channel : channels) {
+          if (channel.getImportance() == NotificationManager.IMPORTANCE_NONE) {
+            return false;
+          }
+        }
+        return true;
+      } else {
+        return NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled();
+      }
+    }
+
   @ReactMethod
   public void checkNotifications(final Promise promise) {
-    final boolean enabled = NotificationManagerCompat
-      .from(getReactApplicationContext()).areNotificationsEnabled();
+    final boolean enabled = areNotificationsEnabled();
     final WritableMap output = Arguments.createMap();
     final WritableMap settings = Arguments.createMap();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

There is an issue with android that are on os version < 10, when we call checkNotifications() method, the result is always 'granted'.

## Test Plan

### What's required for testing (prerequisites)?

Android with os version < 10

### What are the steps to reproduce (after prerequisites)?

Call checkNotifications on RN, run on an android device with os version < 10, turn on the push notifs and see the result, turn off and see. 

## Compatibility

 OS    Implemented
iOS          N/A
Android   ✅

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
