### PR TITLE
Fix homepage ref on npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "license": "MIT",
   "description": "An unified permissions API for React Native on iOS and Android",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",
-  "homepage": "https://github.com/react-native-community/react-native-permissions#readme",
+  "homepage": "https://github.com/zoontek/react-native-permissions#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/react-native-community/react-native-permissions.git"
+    "url": "https://github.com/zoontek/react-native-permissions.git"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
When I search for this library online, the first result is an npm page which links to a github repo that is different from this one. Hence this PR fixes the mismatch.