### PR TITLE
feat(android): add MANAGE_EXTERNAL_STORAGE permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Add all wanted permissions to your app `android/app/src/main/AndroidManifest.xml
   <uses-permission android:name="android.permission.CALL_PHONE" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+  <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS" />
   <uses-permission android:name="android.permission.READ_CALENDAR" />
   <uses-permission android:name="android.permission.READ_CALL_LOG" />

--- a/src/permissions.android.ts
+++ b/src/permissions.android.ts
@@ -13,6 +13,7 @@ const ANDROID = Object.freeze({
   CALL_PHONE: 'android.permission.CALL_PHONE',
   CAMERA: 'android.permission.CAMERA',
   GET_ACCOUNTS: 'android.permission.GET_ACCOUNTS',
+  MANAGE_EXTERNAL_STORAGE: 'android.permission.MANAGE_EXTERNAL_STORAGE',
   PROCESS_OUTGOING_CALLS: 'android.permission.PROCESS_OUTGOING_CALLS',
   READ_CALENDAR: 'android.permission.READ_CALENDAR',
   READ_CALL_LOG: 'android.permission.READ_CALL_LOG',


### PR DESCRIPTION
# Summary

Since Android 11, the OS ignores `requestLegacyExternalStorage` property in `AndroidManifest.xml` and needs to, either remove the global external storage usage, either add another new permission added in API 30 named `MANAGE_EXTERNAL_STORAGE`.

Android recommends to not use this permission, except in some conditions like:
- File storage app
- App storing documents
- Etc

[Source](https://support.google.com/googleplay/android-developer/answer/9956427?hl=en) 

Closes https://github.com/zoontek/react-native-permissions/issues/586

## Test Plan

You only need to require it in Android 11 (API 30+).

### What's required for testing (prerequisites)?

Android 11

### What are the steps to reproduce (after prerequisites)?

Request the permission `PERMISSIONS.ANDROID.MANAGE_EXTERNAL_STORAGE` and let's see if it works.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
