### PR TITLE
fix: export PERMISSIONS

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -1,6 +1,15 @@
-const {PERMISSIONS} = require('./dist/commonjs/permissions');
+const {
+  PERMISSIONS: {ANDROID},
+} = require('./dist/commonjs/permissions.android');
+const {
+  PERMISSIONS: {IOS},
+} = require('./dist/commonjs/permissions.ios');
+const {
+  PERMISSIONS: {WINDOWS},
+} = require('./dist/commonjs/permissions.windows');
 const {RESULTS} = require('./dist/commonjs/results');
 
+const PERMISSIONS = {ANDROID, IOS, WINDOWS};
 export {PERMISSIONS, RESULTS};
 
 export const openLimitedPhotoLibraryPicker = jest.fn(async () => {});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The `PERMISSIONS` that were exported in v2 are not exported in v3. Specifically, the PERMISSIONS object is exported, but the actual object is empty.

This causes an error when migrating from v2 because the permission constants are not found.

In this PR, the `PERMISSIONS` exported from each OS file has been removed and integrated into `permission.ts`.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
* Check the `PERMISSIONS` exported from each OS file is not used from anywhere.
* ran
	* `yarn run lint`
	* `yarn run format`
	* `yarn run tscheck`

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
