### PR TITLE
Adding new Android 12 bluetooth permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ Add all wanted permissions to your app `android/app/src/main/AndroidManifest.xml
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
   <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
+  <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+  <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+  <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
   <uses-permission android:name="android.permission.BODY_SENSORS" />
   <uses-permission android:name="android.permission.CALL_PHONE" />
   <uses-permission android:name="android.permission.CAMERA" />
@@ -466,6 +469,10 @@ PERMISSIONS.ANDROID.WRITE_CALENDAR;
 PERMISSIONS.ANDROID.WRITE_CALL_LOG;
 PERMISSIONS.ANDROID.WRITE_CONTACTS;
 PERMISSIONS.ANDROID.WRITE_EXTERNAL_STORAGE;
+PERMISSIONS.ANDROID.BLUETOOTH_CONNECT;
+PERMISSIONS.ANDROID.BLUETOOTH_SCAN;
+PERMISSIONS.ANDROID.BLUETOOTH_ADVERTISE;
+
 ```
 
 </details>

--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
@@ -127,6 +127,12 @@ public class RNPermissionsModule extends ReactContextBaseJavaModule implements P
       return "WRITE_CONTACTS";
     if (permission.equals("android.permission.WRITE_EXTERNAL_STORAGE"))
       return "WRITE_EXTERNAL_STORAGE";
+    if (permission.equals("android.permission.BLUETOOTH_CONNECT"))
+      return "BLUETOOTH_CONNECT";
+    if (permission.equals("android.permission.BLUETOOTH_SCAN"))
+      return "BLUETOOTH_SCAN";
+    if (permission.equals("android.permission.BLUETOOTH_ADVERTISE"))
+      return "BLUETOOTH_ADVERTISE";
 
     return null;
   }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -196,6 +196,7 @@ dependencies {
     implementation "com.facebook.react:react-native:+"  // From node_modules
 
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    implementation('com.squareup.okhttp3:okhttp:4.9.1')
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
       exclude group:'com.facebook.fbjni'

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
     <uses-permission android:name="android.permission.WRITE_CALL_LOG" />
     <uses-permission android:name="android.permission.WRITE_CONTACTS" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
 
     <application
       android:name=".MainApplication"

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -45,7 +45,8 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.3"
         minSdkVersion = 21
-        compileSdkVersion = 29
-        targetSdkVersion = 29
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "20.1.5948944"
     }
     repositories {

--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 
 module.exports = {
   resolver: {

--- a/src/permissions.android.ts
+++ b/src/permissions.android.ts
@@ -31,6 +31,9 @@ const ANDROID = Object.freeze({
   WRITE_CALL_LOG: 'android.permission.WRITE_CALL_LOG',
   WRITE_CONTACTS: 'android.permission.WRITE_CONTACTS',
   WRITE_EXTERNAL_STORAGE: 'android.permission.WRITE_EXTERNAL_STORAGE',
+  BLUETOOTH_CONNECT: "android.permission.BLUETOOTH_CONNECT",
+  BLUETOOTH_SCAN: "android.permission.BLUETOOTH_SCAN",
+  BLUETOOTH_ADVERTISE: "android.permission.BLUETOOTH_ADVERTISE"
 } as const);
 
 export type AndroidPermissionMap = typeof ANDROID;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

I didn't open any issue for that. I just needed to implement the new android 12 bluetooth permissions in my project and I saw in this library a simple way to solve my problem and contribute to the community. Here are the new permissions in the official Google documentation:

https://developer.android.com/about/versions/12/features/bluetooth-permissions

I implemented this solution updating the example application for android 12 (Api 31) and adding the new implementations in the necessary files (See commits).

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

To test, just run the demo app on an Android 12 device and request the new permissions.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
