### PR TITLE
Make react-native-windows peer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,10 @@
     "react": "16.13.1",
     "react-native": "0.63.3",
     "typescript": "^4.3.5"
+  },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
In npm 7 and npm 8, `npm audit fix` will fail with `Unable to resolve dependency tree` if `react-native-windows` is not installed. As `react-native-permissions` works perfectly on mobile without `react-native-windows`, this should be an optional peer dependency.

Ref https://github.com/luggit/react-native-config/pull/585

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta