### PR TITLE
Feature/add access media location permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A unified permissions API for React Native on iOS, Android and Windows.<br>
 
 | version | react-native version | Xcode version |
 | ------- | -------------------- | ------------- |
-| 3.2.0+  | 0.63.0+              | 12+           |
+| 3.0.0+  | 0.63.0+              | 12+           |
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A unified permissions API for React Native on iOS, Android and Windows.<br>
 
 | version | react-native version | Xcode version |
 | ------- | -------------------- | ------------- |
-| 3.0.0+  | 0.63.0+              | 12+           |
+| 3.2.0+  | 0.63.0+              | 12+           |
 
 ## Setup
 
@@ -160,6 +160,7 @@ Add all wanted permissions to your app `android/app/src/main/AndroidManifest.xml
   <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
   <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
   <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />
   <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
@@ -444,6 +445,7 @@ PERMISSIONS.ANDROID.ACCEPT_HANDOVER;
 PERMISSIONS.ANDROID.ACCESS_BACKGROUND_LOCATION;
 PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION;
 PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION;
+PERMISSIONS.ANDROID.ACCESS_MEDIA_LOCATION;
 PERMISSIONS.ANDROID.ACTIVITY_RECOGNITION;
 PERMISSIONS.ANDROID.ADD_VOICEMAIL;
 PERMISSIONS.ANDROID.ANSWER_PHONE_CALLS;

--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
@@ -77,6 +77,8 @@ public class RNPermissionsModule extends ReactContextBaseJavaModule implements P
       return "ACCESS_COARSE_LOCATION";
     if (permission.equals("android.permission.ACCESS_FINE_LOCATION"))
       return "ACCESS_FINE_LOCATION";
+    if (permission.equals("android.permission.ACCESS_MEDIA_LOCATION"))
+      return "ACCESS_MEDIA_LOCATION";
     if (permission.equals("com.android.voicemail.permission.ADD_VOICEMAIL"))
       return "ADD_VOICEMAIL";
     if (permission.equals("android.permission.ACTIVITY_RECOGNITION"))

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="com.android.voicemail.permission.ADD_VOICEMAIL" />
     <uses-permission android:name="android.permission.ANSWER_PHONE_CALLS" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-permissions",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "description": "An unified permissions API for React Native on iOS, Android and Windows",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-permissions",
-  "version": "3.2.0",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "An unified permissions API for React Native on iOS, Android and Windows",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",

--- a/src/permissions.android.ts
+++ b/src/permissions.android.ts
@@ -6,6 +6,7 @@ const ANDROID = Object.freeze({
   ACCESS_BACKGROUND_LOCATION: 'android.permission.ACCESS_BACKGROUND_LOCATION',
   ACCESS_COARSE_LOCATION: 'android.permission.ACCESS_COARSE_LOCATION',
   ACCESS_FINE_LOCATION: 'android.permission.ACCESS_FINE_LOCATION',
+  ACCESS_MEDIA_LOCATION: 'android.permission.ACCESS_MEDIA_LOCATION',
   ACTIVITY_RECOGNITION: 'android.permission.ACTIVITY_RECOGNITION',
   ADD_VOICEMAIL: 'com.android.voicemail.permission.ADD_VOICEMAIL',
   ANSWER_PHONE_CALLS: 'android.permission.ANSWER_PHONE_CALLS',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The permission is needed to access location tags of media: https://developer.android.com/training/data-storage/shared/media#media-location-permission

## Test Plan

These modifications were tested in a react native app using the patch-package library to install it and have worked.
These outputs show it:
(Real device)
2021-12-02 22:47:45.263 22013-7798/com.blabla.blabla I/ReactNativeJS: { permissions: 
       { 'android.permission.READ_EXTERNAL_STORAGE': 'granted',
         'android.permission.ACCESS_FINE_LOCATION': 'granted',
         'android.permission.ACCESS_MEDIA_LOCATION': 'granted' } }

(Emulator)
2021-12-02 23:02:03.719 3039-3238/com.blabla.blabla I/ReactNativeJS: { permissions: 
       { 'android.permission.ACCESS_FINE_LOCATION': 'granted',
         'android.permission.READ_EXTERNAL_STORAGE': 'granted',
         'android.permission.ACCESS_MEDIA_LOCATION': 'granted' } }

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?
Get pictures tags location in an Android 11 device.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
