### PR TITLE
README: add explanation for RESULTS.UNAVAILABLE for location permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ check(PERMISSIONS.IOS.LOCATION_ALWAYS)
     switch (result) {
       case RESULTS.UNAVAILABLE:
         console.log('This feature is not available (on this device / in this context)');
+        console.log('This can happen e.g. if "Privacy" => "Location Services" is turned off')
         break;
       case RESULTS.DENIED:
         console.log('The permission has not been requested / is denied but requestable');


### PR DESCRIPTION
The previous explanation was correct, but an example of how this could be provoked was missing

# Summary

We ran into an issue because for us it wasn't clear under which circumstances RESULTS.UNAVAILABLE would be returned. The existing documentation was totally correct, but we misunderstood it. Hopefully this change in the README makes it a bit easier to get an understanding of when it might be returned

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I added documentation in `README.md`
