### PR TITLE
feat(android): runtime notifications for sdk-33

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ PERMISSIONS.ANDROID.BODY_SENSORS;
 PERMISSIONS.ANDROID.CALL_PHONE;
 PERMISSIONS.ANDROID.CAMERA;
 PERMISSIONS.ANDROID.GET_ACCOUNTS;
+PERMISSIONS.ANDROID.POST_NOTIFICATIONS;
 PERMISSIONS.ANDROID.PROCESS_OUTGOING_CALLS;
 PERMISSIONS.ANDROID.READ_CALENDAR;
 PERMISSIONS.ANDROID.READ_CALL_LOG;
@@ -788,7 +789,7 @@ checkNotifications().then(({status, settings}) => {
 Request notifications permission status and get notifications settings values.
 
 You cannot request notifications permissions on Windows. Disabling or enabling notifications can only be done through the App Settings.
-You cannot request notifications permissions on Android. `requestNotifications` is the same than `checkNotifications` on this platform.
+`requestNotifications` is iOS-only. To request notifications permissions on Android, use `request(PERMISSIONS.ANDROID.POST_NOTIFICATIONS)`
 
 ```ts
 // only used on iOS

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,11 +20,11 @@ buildscript {
 apply plugin: "com.android.library"
 
 android {
-    compileSdkVersion safeExtGet("compileSdkVersion", 30)
-    buildToolsVersion safeExtGet("buildToolsVersion", "30.0.2")
+    compileSdkVersion safeExtGet("compileSdkVersion", 33)
+    buildToolsVersion safeExtGet("buildToolsVersion", "33.0.0")
     defaultConfig {
         minSdkVersion safeExtGet("minSdkVersion", 21)
-        targetSdkVersion safeExtGet("targetSdkVersion", 30)
+        targetSdkVersion safeExtGet("targetSdkVersion", 33)
     }
     lintOptions {
         abortOnError false

--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
@@ -85,6 +85,8 @@ public class RNPermissionsModule extends ReactContextBaseJavaModule implements P
       return "GET_ACCOUNTS";
     if (permission.equals("android.permission.PROCESS_OUTGOING_CALLS"))
       return "PROCESS_OUTGOING_CALLS";
+    if (permission.equals("android.permission.POST_NOTIFICATIONS"))
+      return "POST_NOTIFICATIONS";
     if (permission.equals("android.permission.READ_CALENDAR"))
       return "READ_CALENDAR";
     if (permission.equals("android.permission.READ_CALL_LOG"))
@@ -141,16 +143,13 @@ public class RNPermissionsModule extends ReactContextBaseJavaModule implements P
 
   @ReactMethod
   public void checkNotifications(final Promise promise) {
-    final boolean enabled = NotificationManagerCompat
-      .from(getReactApplicationContext()).areNotificationsEnabled();
+    if(Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+      this.checkNotificationsCompat(promise);
+      return;
+    }
 
-    final WritableMap output = Arguments.createMap();
-    final WritableMap settings = Arguments.createMap();
-
-    output.putString("status", enabled ? GRANTED : BLOCKED);
-    output.putMap("settings", settings);
-
-    promise.resolve(output);
+    String fieldName = this.getFieldName("android.permission.POST_NOTIFICATIONS");
+    this.checkPermission(fieldName, promise);
   }
 
   @ReactMethod
@@ -366,6 +365,19 @@ public class RNPermissionsModule extends ReactContextBaseJavaModule implements P
     mCallbacks.get(requestCode).invoke(grantResults, getPermissionAwareActivity());
     mCallbacks.remove(requestCode);
     return mCallbacks.size() == 0;
+  }
+
+  private void checkNotificationsCompat(final Promise promise) {
+    final boolean enabled = NotificationManagerCompat
+      .from(getReactApplicationContext()).areNotificationsEnabled();
+
+    final WritableMap output = Arguments.createMap();
+    final WritableMap settings = Arguments.createMap();
+
+    output.putString("status", enabled ? GRANTED : BLOCKED);
+    output.putMap("settings", settings);
+
+    promise.resolve(output);
   }
 
   private PermissionAwareActivity getPermissionAwareActivity() {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.PROCESS_OUTGOING_CALLS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,10 +4,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64

--- a/src/permissions.android.ts
+++ b/src/permissions.android.ts
@@ -17,6 +17,7 @@ const ANDROID = Object.freeze({
   CALL_PHONE: 'android.permission.CALL_PHONE',
   CAMERA: 'android.permission.CAMERA',
   GET_ACCOUNTS: 'android.permission.GET_ACCOUNTS',
+  POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS',
   PROCESS_OUTGOING_CALLS: 'android.permission.PROCESS_OUTGOING_CALLS',
   READ_CALENDAR: 'android.permission.READ_CALENDAR',
   READ_CALL_LOG: 'android.permission.READ_CALL_LOG',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

Makes the package compatible with new Android requirements by adding [runtime notification permission](https://developer.android.com/about/versions/13/changes/notification-permission). Ideally, we could make it compatible with `requestNotifications` on iOS, but I think it's OK to keep it like this for the first iteration and then see where it can be improved. Anyhow, the `options` argument required to be passed to the iOS function is not compatible with Android.

Closes #688

## Test Plan

Run the [example app](https://github.com/zoontek/react-native-permissions/tree/master/example) and play with `POST_NOTIFICATIONS` permission

### What's required for testing (prerequisites)?

Android device/emulator with SDK 33

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` // _There is no CHANGELOG.md_
- [ ] I updated the typed files (TS and Flow) // It's under _.gitignore_
- [x] I added a sample use of the API in the example project (`example/App.js`)
