### PR TITLE
Handle upgrading from location when in use to location always on iOS

### DIFF
--- a/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
+++ b/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
@@ -74,9 +74,9 @@
   // won't trigger the locationManager:didChangeAuthorizationStatus: delegate method. This means we
   // can't know when the user has responded to the permission prompt directly.
   //
-  // We can get around this by listening for UIApplicationDidBecomeActiveNotification event which posts
+  // We can get around this by listening for the UIApplicationDidBecomeActiveNotification event which posts
   // when the application regains focus from the permission prompt. When this happens we'll
-  // trigger the applicationDidBecomeActive method on this class, and we'll check the status and
+  // trigger the applicationDidBecomeActive method on this class, and we'll check the authorization status and
   // resolve the promise there -- letting us stay consistent with our promise-based API.
   //
   // References:

--- a/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
+++ b/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
@@ -29,13 +29,19 @@
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }
-
+  
   switch ([CLLocationManager authorizationStatus]) {
     case kCLAuthorizationStatusNotDetermined:
       return resolve(RNPermissionStatusNotDetermined);
     case kCLAuthorizationStatusRestricted:
       return resolve(RNPermissionStatusRestricted);
-    case kCLAuthorizationStatusAuthorizedWhenInUse:
+    case kCLAuthorizationStatusAuthorizedWhenInUse: {
+      BOOL requestedBefore = [RNPermissions isFlaggedAsRequested:[[self class] handlerUniqueId]];
+      if (requestedBefore) {
+        return resolve(RNPermissionStatusDenied);
+      }
+      return resolve(RNPermissionStatusNotDetermined);
+    }
     case kCLAuthorizationStatusDenied:
       return resolve(RNPermissionStatusDenied);
     case kCLAuthorizationStatusAuthorizedAlways:
@@ -48,23 +54,64 @@
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }
-  if ([CLLocationManager authorizationStatus] != kCLAuthorizationStatusNotDetermined) {
+  
+  CLAuthorizationStatus authorizationStatus = [CLLocationManager authorizationStatus];
+  BOOL requestedBefore = [RNPermissions isFlaggedAsRequested:[[self class] handlerUniqueId]];
+  
+  if (authorizationStatus != kCLAuthorizationStatusNotDetermined
+      && (authorizationStatus == kCLAuthorizationStatusAuthorizedWhenInUse
+          && requestedBefore)) {
     return [self checkWithResolver:resolve rejecter:reject];
   }
-
+  
   _resolve = resolve;
   _reject = reject;
-
+  
   _locationManager = [CLLocationManager new];
   [_locationManager setDelegate:self];
+  
+  // When we request location always permission, if the user selects "Keep Only While Using", iOS
+  // won't trigger the locationManager:didChangeAuthorizationStatus: delegate method. This means we
+  // can't know when the user has responded to the permission prompt directly.
+  //
+  // We can get around this by listening for UIApplicationDidBecomeActiveNotification event which posts
+  // when the application regains focus from the permission prompt. When this happens we'll
+  // trigger the applicationDidBecomeActive method on this class, and we'll check the status and
+  // resolve the promise there -- letting us stay consistent with our promise-based API.
+  //
+  // References:
+  // ===========
+  // CLLocationManager requestAlwaysAuthorization:
+  // https://developer.apple.com/documentation/corelocation/cllocationmanager/1620551-requestalwaysauthorization?language=objc
+  //
+  // NSNotificationCenter addObserver:
+  // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1415360-addobserver
+  //
+  // UIApplicationDidBecomeActiveNotification:
+  // https://developer.apple.com/documentation/uikit/uiapplicationdidbecomeactivenotification
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(applicationDidBecomeActive)
+                                               name:UIApplicationDidBecomeActiveNotification
+                                             object:nil];
+  
   [_locationManager requestAlwaysAuthorization];
+  [RNPermissions flagAsRequested:[[self class] handlerUniqueId]];
+}
+
+- (void)resolveWithNewAuthorizationStatusAndCleanup {
+  [self checkWithResolver:_resolve rejecter:_reject];
+  [_locationManager setDelegate:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:UIApplicationDidBecomeActiveNotification
+                                                object:nil];
+}
+
+- (void)applicationDidBecomeActive {
+  [self resolveWithNewAuthorizationStatusAndCleanup];
 }
 
 - (void)locationManager:(CLLocationManager *)manager didChangeAuthorizationStatus:(CLAuthorizationStatus)status {
-  if (status != kCLAuthorizationStatusNotDetermined) {
-    [_locationManager setDelegate:nil];
-    [self checkWithResolver:_resolve rejecter:_reject];
-  }
+  [self resolveWithNewAuthorizationStatusAndCleanup];
 }
 
 @end


### PR DESCRIPTION
# Summary

* Closes https://github.com/zoontek/react-native-permissions/issues/490
* Fixes an issue on iOS where you could not ask for `LOCATION_ALWAYS` permission if you already had `LOCATION_WHEN_IN_USE` permission.
* This only impacts the `LocationAlways` pod.

## Implementation Changes

- For `check`:
  - If the current authorization status is `AuthorizedWhenInUse`, and we _have not_ requested `LOCATION_ALWAYS` in the past, we return `NotDetermined`.
  - If the current authorization status is `AuthorizedWhenInUse` and we _have_ requested `LOCATION_ALWAYS` in the past, we return `Denied`, since we're not allowed to prompt for this permission twice.
- For `request`:
  - If the current authorization status is `AuthorizedWhenInUse` and we _have not_ requested `LOCATION_ALWAYS` in the past, we call `requestAlwaysAuthorization` and flag the permission as requested.
  - If the current authorization status is `AuthorizedWhenInUse` and we _have_ requested `LOCATION_ALWAYS` in the past, then we return the current authorization result, since we're not allowed to prompt for this permission twice.

## Test Plan

- Request and grant `LOCATION_WHEN_IN_USE` permission.
- Then request `LOCATION_ALWAYS` permission.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/15325890/95513095-6611e700-09d7-11eb-8794-f81367c98cca.gif) | ![After](https://user-images.githubusercontent.com/15325890/95513105-68744100-09d7-11eb-91b2-ed016b298c4b.gif) |

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    N/A   |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [X] I added a sample use of the API in the example project (`example/App.tsx`)
