### PR TITLE
fix: allow LocationAlways permission request when current status is kCLAuthorizationStatusAuthorizedWhenInUse

### DIFF
--- a/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
+++ b/ios/LocationAlways/RNPermissionHandlerLocationAlways.m
@@ -36,6 +36,7 @@
     case kCLAuthorizationStatusRestricted:
       return resolve(RNPermissionStatusRestricted);
     case kCLAuthorizationStatusAuthorizedWhenInUse:
+      return resolve(RNPermissionStatusNotDetermined);
     case kCLAuthorizationStatusDenied:
       return resolve(RNPermissionStatusDenied);
     case kCLAuthorizationStatusAuthorizedAlways:
@@ -48,7 +49,7 @@
   if (![CLLocationManager locationServicesEnabled]) {
     return resolve(RNPermissionStatusNotAvailable);
   }
-  if ([CLLocationManager authorizationStatus] != kCLAuthorizationStatusNotDetermined) {
+  if (([CLLocationManager authorizationStatus] != kCLAuthorizationStatusNotDetermined) && ([CLLocationManager authorizationStatus] != kCLAuthorizationStatusAuthorizedWhenInUse)) {
     return [self checkWithResolver:resolve rejecter:reject];
   }
 


### PR DESCRIPTION
Same issue explained at https://github.com/zoontek/react-native-permissions/pull/716

The fix let the module accept requesting for LocationAlways permission, once we have previously requested the LocationWhenInUse permission.

This scenario is not working on the current master branch.