### PR TITLE
update NotificationOption type

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,9 @@ type NotificationOption =
   | 'criticalAlert'
   | 'carPlay'
   | 'provisional'
-  | 'providesAppSettings';
+  | 'providesAppSettings'
+  | 'lockScreen'
+  | 'notificationCenter';
 
 type NotificationSettings = {
   // properties only available on iOS

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,9 @@ export type NotificationOption =
   | 'carPlay'
   | 'criticalAlert'
   | 'provisional'
-  | 'providesAppSettings';
+  | 'providesAppSettings'
+  | 'lockScreen'
+  | 'notificationCenter';
 
 export type NotificationSettings = {
   alert?: boolean;


### PR DESCRIPTION
# Summary

PR includes an update for `NotificationOption` type

`checkNotifications` returns `settings` based on the `NotificationSettings` type, but we can't request the full list option in the `requestNotifications` because of `NotificationOption` type.
i tried to pass missed `lockScreen` and  `'notificationCenter'` to the `requestNotifications` method and  get needed permissions. i think, they were missed and not included in some of pr

## Test Plan

### What's required for testing (prerequisites)?

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
