### PR TITLE
Silently Fail onRequestPermissionsResult for Invalid Activities

### DIFF
--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModule.java
@@ -411,9 +411,13 @@ public class RNPermissionsModule extends NativePermissionsModuleSpec implements 
 
   @Override
   public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-    mCallbacks.get(requestCode).invoke(grantResults, getPermissionAwareActivity());
-    mCallbacks.remove(requestCode);
-    return mCallbacks.size() == 0;
+    try {
+      mCallbacks.get(requestCode).invoke(grantResults, getPermissionAwareActivity());
+      mCallbacks.remove(requestCode);
+      return mCallbacks.size() == 0;
+    } catch (IllegalStateException e) {
+      return false;
+    }
   }
 
   private PermissionAwareActivity getPermissionAwareActivity() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-permissions",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "license": "MIT",
   "description": "An unified permissions API for React Native on iOS, Android and Windows",
   "author": "Mathieu Acthernoene <zoontek@gmail.com>",


### PR DESCRIPTION
# Summary

react-native-permissions causes crashes to android users in different situations that are hard to replicate, but are clearly visible through crashlogs and analytics, affecting up to 15% of users on different devices and OS versions, with different versions of react-native-permissions in the past 6+ months.

## Crash report
```
com.zoontek.rnpermissions.RNPermissionsModule.onRequestPermissionsResult
java.lang.NullPointerException: Attempt to invoke interface method 'void com.facebook.react.bridge.Callback.invoke(java.lang.Object[])' on a null object reference
```

## Similar reported issues / topics

The issue has been fixed by react-native in a previous release, based on this [PR](https://github.com/facebook/react-native/pull/37047) and it's [changed files](https://github.com/facebook/react-native/pull/37047/files). Current PR only aligns react-native-permissions with the main fix released on react-native.

- https://github.com/facebook/react-native/issues/29056

The impact of the change is minimal.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅    |
| Android |    ✅     |

## Checklist

- [X] I have tested this on multiple devices and simulators