### PR TITLE
feat(iOS): support media library permission request on Simulator.

### DIFF
--- a/ios/MediaLibrary/RNPermissionHandlerMediaLibrary.m
+++ b/ios/MediaLibrary/RNPermissionHandlerMediaLibrary.m
@@ -14,7 +14,7 @@
 
 - (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                  rejecter:(void (__unused ^ _Nonnull)(NSError * _Nonnull))reject {
-#if TARGET_OS_SIMULATOR || TARGET_OS_TV
+#if TARGET_OS_TV
   resolve(RNPermissionStatusNotAvailable);
 #else
   switch ([MPMediaLibrary authorizationStatus]) {
@@ -32,7 +32,7 @@
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                    rejecter:(void (^ _Nonnull)(NSError * _Nonnull))reject {
-#if TARGET_OS_SIMULATOR || TARGET_OS_TV
+#if TARGET_OS_TV
   resolve(RNPermissionStatusNotAvailable);
 #else
   [MPMediaLibrary requestAuthorization:^(__unused MPMediaLibraryAuthorizationStatus status) {


### PR DESCRIPTION
Seems like requesting / checking media library permissions works as expected on iOS simulator. 
Not sure why it was hard-coded disabled  here (maybe because of old Apple bug).