### PR TITLE
add apple privacy manifest & usage descriptions for UserDefaults

### DIFF
--- a/RNPermissions.podspec
+++ b/RNPermissions.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => package["repository"]["url"], :tag => s.version }
   s.source_files = "ios/*.{h,mm}"
   # s.frameworks = <frameworks>
+  s.resource_bundles = { 'RNPermissions_PrivacyInfo' => 'ios/Resources/PrivacyInfo.xcprivacy' }
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == "1" then
     install_modules_dependencies(s)

--- a/ios/Resources/PrivacyInfo.xcprivacy
+++ b/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyTracking</key>
+  <false/>
+  <key>NSPrivacyTrackingDomains</key>
+  <array/>
+  <key>NSPrivacyCollectedDataTypes</key>
+  <array/>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array>
+    <dict>
+      <key>NSPrivacyAccessedAPIType</key>
+      <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+      <key>NSPrivacyAccessedAPITypeReasons</key>
+      <array>
+        <string>CA92.1</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>


### PR DESCRIPTION
# Summary

#830 

Starting May 1, Apple will enforce 3rd party SDK's to sign & provide privacy manifests for specific API's being accessed by the code. This change adds a privacy manifest and reason for using the data. [Apple Documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)

I have added a declaration for use of `UserDefualts` via `NSPrivacyAccessedAPICategoryUserDefaults` and from reading the code have stated the reason 
```
CA92.1
Declare this reason to access user defaults to read and write information that is only accessible to the app itself.

This reason does not permit reading information that was written by other apps or the system, or writing information that can be accessed by other apps.
```



## Test Plan


### What's required for testing (prerequisites)?
Build and run the example app

### What are the steps to test it (after prerequisites)?
Upon building the IPA you can inspect the IPA and find `RNPermissions_PrivacyInfo.bundle` and within that find `PrivacyInfo.xcprivacy`

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)

## Notes
- iOS Only
- No changes required to documentation
- No additions required for the example project