### PR TITLE
Compatible with AGP versions below 4.2.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ android {
     buildToolsVersion safeExtGet("buildToolsVersion", "33.0.0")
     compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     if (project.android.hasProperty("namespace")) {
         namespace "com.zoontek.rnpermissions"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
react-native-permission uses lambda expressions and cannot be compiled in projects with AGP versions lower than 4.2.0.
Therefore, add compileOptions to compile with Java 8.

https://developer.android.com/build/releases/past-releases/agp-4-2-0-release-notes
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
AGP versions lower than 4.2.0

### What are the steps to test it (after prerequisites)?
Compiling with AGP lower than 4.2.0 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator