### PR TITLE
Added limited contact permission support for iOS 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ Permission checks and requests resolve into one of these statuses:
 | `RESULTS.DENIED`      | The permission has not been requested / is denied but requestable                                                          |
 | `RESULTS.BLOCKED`     | The permission is denied and not requestable anymore                                                                       |
 | `RESULTS.GRANTED`     | The permission is granted                                                                                                  |
-| `RESULTS.LIMITED`     | The permission is granted but with limitations<br>_Only for iOS `PhotoLibrary`, `PhotoLibraryAddOnly` and `Notifications`_ |
+| `RESULTS.LIMITED`     | The permission is granted but with limitations<br>_Only for iOS `PhotoLibrary`, `PhotoLibraryAddOnly`, `Contacts` and `Notifications`_ |
 
 ### Methods
 

--- a/ios/Contacts/RNPermissionHandlerContacts.mm
+++ b/ios/Contacts/RNPermissionHandlerContacts.mm
@@ -14,16 +14,31 @@
 
 - (void)checkWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve
                  rejecter:(void (__unused ^ _Nonnull)(NSError * _Nonnull))reject {
-  switch ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts]) {
-    case CNAuthorizationStatusNotDetermined:
-      return resolve(RNPermissionStatusNotDetermined);
-    case CNAuthorizationStatusRestricted:
-      return resolve(RNPermissionStatusRestricted);
-    case CNAuthorizationStatusDenied:
-      return resolve(RNPermissionStatusDenied);
-    case CNAuthorizationStatusAuthorized:
-      return resolve(RNPermissionStatusAuthorized);
-  }
+  if (@available(iOS 18.0, *)) {
+    switch ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts]) {       
+      case CNAuthorizationStatusNotDetermined:
+        return resolve(RNPermissionStatusNotDetermined);
+      case CNAuthorizationStatusRestricted:
+        return resolve(RNPermissionStatusRestricted);
+      case CNAuthorizationStatusDenied:
+        return resolve(RNPermissionStatusDenied);
+      case CNAuthorizationStatusAuthorized:
+        return resolve(RNPermissionStatusAuthorized);
+      case CNAuthorizationStatusLimited:
+        return resolve(RNPermissionStatusLimited); 
+    } 
+  } else {
+    switch ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts]) {   
+      case CNAuthorizationStatusNotDetermined:
+        return resolve(RNPermissionStatusNotDetermined);
+      case CNAuthorizationStatusRestricted:
+        return resolve(RNPermissionStatusRestricted);
+      case CNAuthorizationStatusDenied:
+        return resolve(RNPermissionStatusDenied);
+      case CNAuthorizationStatusAuthorized:
+        return resolve(RNPermissionStatusAuthorized);
+    }
+  } 
 }
 
 - (void)requestWithResolver:(void (^ _Nonnull)(RNPermissionStatus))resolve


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

The limited contact permission is coming for iOS 18 ([Apple's documentation](https://developer.apple.com/documentation/contacts/cnauthorizationstatus/limited)). The PR is to support that

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

- iOS 18.0 beta 5
- Xcode Version 16.0 beta 5

### What are the steps to test it (after prerequisites)?

1. Launch the react-native-permission example app on iOS 18.0 beta 1 on Xcode Version 16.0 beta 1
2. Click on the contacts request
3. Select only limited contacts as shown in the below recording

Expected result: The Contacts permission result should be "limited"

https://github.com/zoontek/react-native-permissions/assets/1524485/34df2326-e78b-4597-b657-310191e87948


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I added a sample use of the API in the example project (`example/App.tsx`) - N/A the contact permission example already existed
