### PR TITLE
fix typo at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ yarn add react-native-permissions
 
 ### iOS
 
-1. By default, no permissions are avalaible. First, require the `setup` script in your `Podfile`:
+1. By default, no permissions are available. First, require the `setup` script in your `Podfile`:
 
 ```diff
 # Transform this into a `node_require` generic function:


### PR DESCRIPTION
Hello, I found a typo in the IOS section of the README.md.
I changed "avalaible" as "available".