### PR TITLE
check permission for null values to fix Android build issue in RN 0.77.0-rc.7

### DIFF
--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModuleImpl.kt
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModuleImpl.kt
@@ -128,7 +128,9 @@ object RNPermissionsModuleImpl {
 
     for (i in 0 until permissions.size()) {
       val permission = permissions.getString(i)
-
+      if (permission.isNullOrBlank()) {
+        continue;
+      }
       output.putString(
         permission,
         when {
@@ -210,7 +212,9 @@ object RNPermissionsModuleImpl {
 
     for (i in 0 until permissions.size()) {
       val permission = permissions.getString(i)
-
+      if (permission.isNullOrBlank()) {
+        continue;
+      }
       if (!isPermissionAvailable(permission)) {
         output.putString(permission, UNAVAILABLE)
         checkedPermissionsCount++


### PR DESCRIPTION
# Summary
Fixes Android build on RN 0.77.0-rc.7

Fixes https://github.com/zoontek/react-native-permissions/issues/921

## Test Plan
Update RN to 0.77.0-rc.7 and try to build the project.

- [ X] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
