### PR TITLE
Return Limited / Granted on request, instead of always Granted

### DIFF
--- a/ios/Contacts/RNPermissionHandlerContacts.mm
+++ b/ios/Contacts/RNPermissionHandlerContacts.mm
@@ -43,7 +43,7 @@
     if (error != nil && error.code != 100) { // error code 100 is permission denied
       reject(error);
     } else {
-      resolve(granted ? RNPermissionStatusAuthorized : [self currentStatus]);
+      resolve([self currentStatus]);
     }
   }];
 #endif


### PR DESCRIPTION
# Summary

When requesting Contacts permissions on iOS, we'd return `RESULTS.GRANTED`  even when the user provides `LIMITED` permissions.

Instead of returning granted based on boolean return, just return the status directly

## Test Plan
- Reset permissions in app `xcrun simctl privacy booted reset contacts <APP_ID>`
- Allow limited on first go --> should return limited. Allow full access on first go --> should return granted


### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
