### PR TITLE
fix(android): restore POST_NOTIFICATIONS permission

### DIFF
--- a/src/permissions.android.ts
+++ b/src/permissions.android.ts
@@ -19,6 +19,7 @@ const ANDROID = Object.freeze({
   CAMERA: 'android.permission.CAMERA',
   GET_ACCOUNTS: 'android.permission.GET_ACCOUNTS',
   NEARBY_WIFI_DEVICES: 'android.permission.NEARBY_WIFI_DEVICES',
+  POST_NOTIFICATIONS: 'android.permission.POST_NOTIFICATIONS',
   PROCESS_OUTGOING_CALLS: 'android.permission.PROCESS_OUTGOING_CALLS',
   READ_CALENDAR: 'android.permission.READ_CALENDAR',
   READ_CALL_LOG: 'android.permission.READ_CALL_LOG',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

This PR restores the `POST_NOTIFICATIONS` permission for Android that was inadvertently removed in the last version. This permission is essential for apps that need to display notifications on Android 13 and above, as starting from this version Android requires this explicit permission for notification posting. Issue related #940

The absence of this permission was causing failures in apps that depended on it to display notifications, especially on Android 13+ devices.

## Test Plan

### What's required for testing (prerequisites)?
- A device or emulator running Android 13 (API level 33) or higher
- React Native app configured to use react-native-permissions

### What are the steps to test it (after prerequisites)?
1.Import the POST_NOTIFICATIONS permission from the permissions module:
   ```javascript
   import { PERMISSIONS } from 'react-native-permissions';
   ```

2. Request permission in the code:
  ```javascript
  PERMISSIONS.ANDROID.POST_NOTIFICATIONS
  ```

3. Verify that permission is requested correctly from user on Android 13+ device
4. Confirm that the app can send notifications after permission is granted

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in README.md
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
