### PR TITLE
Update documentation with one-time permission info for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ Add all wanted permissions to your app `android/app/src/main/AndroidManifest.xml
 </manifest>
 ```
 
+> On Android 11+:
+>
+> When a user grants a one-time permission (such as for location, camera, or microphone), Android treats the session as active while the app is in use — even if it's backgrounded or reopened shortly after being closed. One-time permissions are not revoked immediately.
+>
+> The system will revoke the permission automatically:
+>
+> - If the app is terminated (e.g. swiped away or force-closed), the permission is typically revoked within **30 to 60 seconds**.
+> - If the app is backgrounded and unused, the permission is also usually revoked within **30 to 60 seconds**.
+>
+> The exact timing may vary depending on the Android version and device. This behavior is designed to protect user privacy without disrupting the app experience.
+>
+> See the official Android documentation [Android 11 permissions documentation](https://developer.android.com/about/versions/11/privacy/permissions#one-time-permission).
+
 ### Expo
 
 If you use Expo, the previous sections don't apply. Instead just update your `app.json` file with the corresponding values, but using the syntax exemplified below:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

There is no clear or detailed explanation in the official Android documentation about how one-time permissions behave after being granted. In practice, these permissions (e.g., location, camera, or microphone) are not revoked immediately when the app is backgrounded or closed - they are typically revoked automatically within 30–60 seconds after the app is no longer in use.

This PR updates the README to document this behavior in the Android setup section. The goal is to help developers better understand how one-time permissions work on Android 11+ and avoid confusion during testing.

This also addresses the following issue: https://github.com/zoontek/react-native-permissions/issues/869#issuecomment-2066015840

## Test Plan

No testing required.

### What's required for testing (prerequisites)?

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/App.tsx`)
