### PR TITLE
Add openContactsPicker to edit the limited contacts selection on iOS 18+

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,20 @@ canUseFullScreenIntent()
   .catch(() => console.warn('Cannot check full screen intent using setting'));
 ```
 
+#### openContactsPicker (iOS 18+)
+
+Open a picker to update the contacts selection when `Contacts` permission is `limited`. This will reject if unsupported or if full permission is already `granted`.
+
+```ts
+function openContactsPicker(): Promise<void>;
+```
+
+```ts
+import {openContactsPicker} from 'react-native-permissions';
+
+openContactsPicker().catch(() => console.warn('Cannot open contact access picker'));
+```
+
 #### openPhotoPicker (iOS 14+)
 
 Open a picker to update the photo selection when `PhotoLibrary` permission is `limited`. This will reject if unsupported or if full permission is already `granted`.

--- a/README.md
+++ b/README.md
@@ -907,18 +907,18 @@ canUseFullScreenIntent()
   .catch(() => console.warn('Cannot check full screen intent using setting'));
 ```
 
-#### openContactsPicker (iOS 18+)
+#### openContactPicker (iOS 18+)
 
 Open a picker to update the contacts selection when `Contacts` permission is `limited`. This will reject if unsupported or if full permission is already `granted`.
 
 ```ts
-function openContactsPicker(): Promise<void>;
+function openContactPicker(): Promise<void>;
 ```
 
 ```ts
-import {openContactsPicker} from 'react-native-permissions';
+import {openContactPicker} from 'react-native-permissions';
 
-openContactsPicker().catch(() => console.warn('Cannot open contact access picker'));
+openContactPicker().catch(() => console.warn('Cannot open contact access picker'));
 ```
 
 #### openPhotoPicker (iOS 14+)

--- a/RNPermissions.podspec
+++ b/RNPermissions.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
 
   s.platforms        = { :ios => "12.4", :tvos => "12.4" }
   s.requires_arc     = true
+  s.swift_version    = "5.9"
 
   s.source           = { :git => package["repository"]["url"], :tag => s.version }
   s.resource_bundles = { 'RNPermissionsPrivacyInfo' => 'ios/PrivacyInfo.xcprivacy' }

--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModuleImpl.kt
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModuleImpl.kt
@@ -303,8 +303,8 @@ object RNPermissionsModuleImpl {
     return activity
   }
 
-  fun openContactsPicker(promise: Promise) {
-    promise.reject("Permissions:openContactsPicker", "openContactsPicker is not supported on Android")
+  fun openContactPicker(promise: Promise) {
+    promise.reject("Permissions:openContactPicker", "openContactPicker is not supported on Android")
   }
 
   fun openPhotoPicker(promise: Promise) {

--- a/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModuleImpl.kt
+++ b/android/src/main/java/com/zoontek/rnpermissions/RNPermissionsModuleImpl.kt
@@ -303,6 +303,10 @@ object RNPermissionsModuleImpl {
     return activity
   }
 
+  fun openContactsPicker(promise: Promise) {
+    promise.reject("Permissions:openContactsPicker", "openContactsPicker is not supported on Android")
+  }
+
   fun openPhotoPicker(promise: Promise) {
     promise.reject("Permissions:openPhotoPicker", "openPhotoPicker is not supported on Android")
   }

--- a/android/src/newarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
+++ b/android/src/newarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
@@ -67,6 +67,10 @@ class RNPermissionsModule(reactContext: ReactApplicationContext?) :
     RNPermissionsModuleImpl.requestLocationAccuracy(promise)
   }
 
+  override fun openContactsPicker(promise: Promise) {
+    RNPermissionsModuleImpl.openContactsPicker(promise)
+  }
+
   override fun openPhotoPicker(promise: Promise) {
     RNPermissionsModuleImpl.openPhotoPicker(promise)
   }

--- a/android/src/newarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
+++ b/android/src/newarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
@@ -67,8 +67,8 @@ class RNPermissionsModule(reactContext: ReactApplicationContext?) :
     RNPermissionsModuleImpl.requestLocationAccuracy(promise)
   }
 
-  override fun openContactsPicker(promise: Promise) {
-    RNPermissionsModuleImpl.openContactsPicker(promise)
+  override fun openContactPicker(promise: Promise) {
+    RNPermissionsModuleImpl.openContactPicker(promise)
   }
 
   override fun openPhotoPicker(promise: Promise) {

--- a/android/src/oldarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
+++ b/android/src/oldarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
@@ -82,8 +82,8 @@ class RNPermissionsModule(reactContext: ReactApplicationContext?) :
   }
 
   @ReactMethod
-  fun openContactsPicker(promise: Promise) {
-    RNPermissionsModuleImpl.openContactsPicker(promise)
+  fun openContactPicker(promise: Promise) {
+    RNPermissionsModuleImpl.openContactPicker(promise)
   }
 
   @ReactMethod

--- a/android/src/oldarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
+++ b/android/src/oldarch/com/zoontek/rnpermissions/RNPermissionsModule.kt
@@ -82,6 +82,11 @@ class RNPermissionsModule(reactContext: ReactApplicationContext?) :
   }
 
   @ReactMethod
+  fun openContactsPicker(promise: Promise) {
+    RNPermissionsModuleImpl.openContactsPicker(promise)
+  }
+
+  @ReactMethod
   fun openPhotoPicker(promise: Promise) {
     RNPermissionsModuleImpl.openPhotoPicker(promise)
   }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2208,7 +2208,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 797de5178718324c6eba3327b07f9a423fbd5787
   ReactCommon: 07572bf9e687c8a52fbe4a3641e9e3a1a477c78e
   ReactNativeDependencies: 6b1f2a357b797abb210774d5c614f76ddb11b46c
-  RNPermissions: 4ac58632a0b89a809af5ada51ab1d5b5ea9f49e0
+  RNPermissions: dde602255052850b3d46e8025486555a8c8d920f
   RNVectorIcons: 4351544f100d4f12cac156a7c13399e60bab3e26
   Yoga: c0b3f2c7e8d3e327e450223a2414ca3fa296b9a2
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -36,6 +36,17 @@ export const App = () => {
 
         {Platform.OS === 'ios' && (
           <Appbar.Action
+            icon="account-multiple"
+            onPress={() => {
+              RNPermissions.openContactsPicker().catch((error) => {
+                console.error(error);
+              });
+            }}
+          />
+        )}
+
+        {Platform.OS === 'ios' && (
+          <Appbar.Action
             icon="image-multiple"
             onPress={() => {
               RNPermissions.openPhotoPicker().catch((error) => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -38,7 +38,7 @@ export const App = () => {
           <Appbar.Action
             icon="account-multiple"
             onPress={() => {
-              RNPermissions.openContactsPicker().catch((error) => {
+              RNPermissions.openContactPicker().catch((error) => {
                 console.error(error);
               });
             }}

--- a/ios/Contacts/RNPermissionHandlerContacts.h
+++ b/ios/Contacts/RNPermissionHandlerContacts.h
@@ -2,4 +2,7 @@
 
 @interface RNPermissionHandlerContacts : NSObject<RNPermissionHandler>
 
+- (void)openContactsPickerWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve
+                              rejecter:(RCTPromiseRejectBlock _Nonnull)reject;
+
 @end

--- a/ios/Contacts/RNPermissionHandlerContacts.h
+++ b/ios/Contacts/RNPermissionHandlerContacts.h
@@ -2,7 +2,7 @@
 
 @interface RNPermissionHandlerContacts : NSObject<RNPermissionHandler>
 
-- (void)openContactsPickerWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve
+- (void)openContactPickerWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve
                               rejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 
 @end

--- a/ios/Contacts/RNPermissionHandlerContacts.mm
+++ b/ios/Contacts/RNPermissionHandlerContacts.mm
@@ -74,7 +74,13 @@
       return reject(@"cannot_open_limited_picker", @"Contact access picker is unavailable", nil);
     }
 
-    [(id<RNPermissionsContactsPickerInterface>)picker presentFrom:RCTPresentedViewController()
+    UIViewController *viewController = RCTPresentedViewController();
+
+    if (viewController == nil) {
+      return reject(@"cannot_open_limited_picker", @"No presented view controller to present from", nil);
+    }
+
+    [(id<RNPermissionsContactsPickerInterface>)picker presentFrom:viewController
                                                        completion:^{
       resolve(@(true));
     }];

--- a/ios/Contacts/RNPermissionHandlerContacts.mm
+++ b/ios/Contacts/RNPermissionHandlerContacts.mm
@@ -1,7 +1,13 @@
 #import "RNPermissionHandlerContacts.h"
+#import <React/RCTUtils.h>
 
 #if !TARGET_OS_TV
 #import <Contacts/Contacts.h>
+
+@protocol RNPermissionsContactsPickerInterface
+- (void)presentFrom:(UIViewController * _Nonnull)viewController
+         completion:(void (^ _Nonnull)(void))completion;
+@end
 #endif
 
 @implementation RNPermissionHandlerContacts
@@ -49,6 +55,32 @@
       resolve([self currentStatus]);
     }
   }];
+#endif
+}
+
+- (void)openContactsPickerWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve
+                              rejecter:(RCTPromiseRejectBlock _Nonnull)reject {
+#if TARGET_OS_TV
+  reject(@"cannot_open_limited_picker", @"Only available on iOS 18 or higher", nil);
+#else
+  if (@available(iOS 18.0, *)) {
+    if ([CNContactStore authorizationStatusForEntityType:CNEntityTypeContacts] != CNAuthorizationStatusLimited) {
+      return reject(@"cannot_open_limited_picker", @"Contacts permission isn't limited", nil);
+    }
+
+    id picker = NSClassFromString(@"RNPermissionsContactsPicker");
+
+    if (picker == nil) {
+      return reject(@"cannot_open_limited_picker", @"Contact access picker is unavailable", nil);
+    }
+
+    [(id<RNPermissionsContactsPickerInterface>)picker presentFrom:RCTPresentedViewController()
+                                                       completion:^{
+      resolve(@(true));
+    }];
+  } else {
+    reject(@"cannot_open_limited_picker", @"Only available on iOS 18 or higher", nil);
+  }
 #endif
 }
 

--- a/ios/Contacts/RNPermissionHandlerContacts.mm
+++ b/ios/Contacts/RNPermissionHandlerContacts.mm
@@ -4,7 +4,7 @@
 #if !TARGET_OS_TV
 #import <Contacts/Contacts.h>
 
-@protocol RNPermissionsContactsPickerInterface
+@protocol RNPermissionsContactPickerInterface
 - (void)presentFrom:(UIViewController * _Nonnull)viewController
          completion:(void (^ _Nonnull)(void))completion;
 @end
@@ -58,7 +58,7 @@
 #endif
 }
 
-- (void)openContactsPickerWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve
+- (void)openContactPickerWithResolver:(RCTPromiseResolveBlock _Nonnull)resolve
                               rejecter:(RCTPromiseRejectBlock _Nonnull)reject {
 #if TARGET_OS_TV
   reject(@"cannot_open_limited_picker", @"Only available on iOS 18 or higher", nil);
@@ -68,7 +68,7 @@
       return reject(@"cannot_open_limited_picker", @"Contacts permission isn't limited", nil);
     }
 
-    id picker = NSClassFromString(@"RNPermissionsContactsPicker");
+    id picker = NSClassFromString(@"RNPermissionsContactPicker");
 
     if (picker == nil) {
       return reject(@"cannot_open_limited_picker", @"Contact access picker is unavailable", nil);
@@ -80,8 +80,8 @@
       return reject(@"cannot_open_limited_picker", @"No presented view controller to present from", nil);
     }
 
-    [(id<RNPermissionsContactsPickerInterface>)picker presentFrom:viewController
-                                                       completion:^{
+    [(id<RNPermissionsContactPickerInterface>)picker presentFrom:viewController
+                                                      completion:^{
       resolve(@(true));
     }];
   } else {

--- a/ios/Contacts/RNPermissionsContactPicker.swift
+++ b/ios/Contacts/RNPermissionsContactPicker.swift
@@ -25,8 +25,8 @@ private struct ContactAccessPickerView: View {
 }
 
 @available(iOS 18.0, *)
-@objc(RNPermissionsContactsPicker)
-public class RNPermissionsContactsPicker: NSObject {
+@objc(RNPermissionsContactPicker)
+public class RNPermissionsContactPicker: NSObject {
   @objc public static func present(
     from viewController: UIViewController,
     completion: @escaping () -> Void

--- a/ios/Contacts/RNPermissionsContactsPicker.swift
+++ b/ios/Contacts/RNPermissionsContactsPicker.swift
@@ -14,7 +14,11 @@ private struct ContactAccessPickerView: View {
       .onAppear { isPresented = true }
       .onChange(of: isPresented) { _, visible in
         if !visible {
-          onDismiss()
+          // Defer to the next runloop so UIKit finishes dismissing the
+          // (out-of-process) picker before we tear down its host controller.
+          DispatchQueue.main.async {
+            onDismiss()
+          }
         }
       }
   }
@@ -27,7 +31,7 @@ public class RNPermissionsContactsPicker: NSObject {
     from viewController: UIViewController,
     completion: @escaping () -> Void
   ) {
-    var host: UIHostingController<ContactAccessPickerView>?
+    weak var host: UIHostingController<ContactAccessPickerView>?
 
     let controller = UIHostingController(rootView: ContactAccessPickerView {
       host?.dismiss(animated: false, completion: completion)

--- a/ios/Contacts/RNPermissionsContactsPicker.swift
+++ b/ios/Contacts/RNPermissionsContactsPicker.swift
@@ -1,0 +1,43 @@
+#if os(iOS)
+import ContactsUI
+import SwiftUI
+import UIKit
+
+@available(iOS 18.0, *)
+private struct ContactAccessPickerView: View {
+  @State private var isPresented = false
+  let onDismiss: () -> Void
+
+  var body: some View {
+    Color.clear
+      .contactAccessPicker(isPresented: $isPresented) { _ in }
+      .onAppear { isPresented = true }
+      .onChange(of: isPresented) { _, visible in
+        if !visible {
+          onDismiss()
+        }
+      }
+  }
+}
+
+@available(iOS 18.0, *)
+@objc(RNPermissionsContactsPicker)
+public class RNPermissionsContactsPicker: NSObject {
+  @objc public static func present(
+    from viewController: UIViewController,
+    completion: @escaping () -> Void
+  ) {
+    var host: UIHostingController<ContactAccessPickerView>?
+
+    let controller = UIHostingController(rootView: ContactAccessPickerView {
+      host?.dismiss(animated: false, completion: completion)
+    })
+
+    controller.modalPresentationStyle = .overFullScreen
+    controller.view.backgroundColor = .clear
+    host = controller
+
+    viewController.present(controller, animated: false)
+  }
+}
+#endif

--- a/ios/RNPermissions.mm
+++ b/ios/RNPermissions.mm
@@ -407,11 +407,11 @@ RCT_EXPORT_METHOD(requestNotifications:(NSArray<NSString *> * _Nonnull)options
 #endif
 }
 
-RCT_EXPORT_METHOD(openContactsPicker:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(openContactPicker:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
 #if __has_include("RNPermissionHandlerContacts.h")
   RNPermissionHandlerContacts *handler = [RNPermissionHandlerContacts new];
-  [handler openContactsPickerWithResolver:resolve rejecter:reject];
+  [handler openContactPickerWithResolver:resolve rejecter:reject];
 #else
   reject(@"contacts_pod_missing", @"Contacts permission pod is missing", nil);
 #endif

--- a/ios/RNPermissions.mm
+++ b/ios/RNPermissions.mm
@@ -407,6 +407,16 @@ RCT_EXPORT_METHOD(requestNotifications:(NSArray<NSString *> * _Nonnull)options
 #endif
 }
 
+RCT_EXPORT_METHOD(openContactsPicker:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+#if __has_include("RNPermissionHandlerContacts.h")
+  RNPermissionHandlerContacts *handler = [RNPermissionHandlerContacts new];
+  [handler openContactsPickerWithResolver:resolve rejecter:reject];
+#else
+  reject(@"contacts_pod_missing", @"Contacts permission pod is missing", nil);
+#endif
+}
+
 RCT_EXPORT_METHOD(openPhotoPicker:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
 #if __has_include("RNPermissionHandlerPhotoLibrary.h")

--- a/scripts/setup.rb
+++ b/scripts/setup.rb
@@ -15,7 +15,7 @@ def setup_permissions(config)
     'Calendars' => ['EventKit'],
     'CalendarsWriteOnly' => ['EventKit'],
     'Camera' => ['AVFoundation'],
-    'Contacts' => ['Contacts'],
+    'Contacts' => ['Contacts', 'ContactsUI'],
     'FaceID' => ['LocalAuthentication'],
     'LocationAccuracy' => ['CoreLocation'],
     'LocationAlways' => ['CoreLocation'],
@@ -49,7 +49,7 @@ def setup_permissions(config)
 
   source_files = [
     '"ios/*.{h,mm}"',
-    *directories.map { |name| "\"ios/#{name}/*.{h,mm}\"" }
+    *directories.map { |name| "\"ios/#{name}/*.{h,mm,swift}\"" }
   ].join(', ')
 
   frameworks = directories

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -17,7 +17,7 @@ export type Contract = {
     permissions: P,
   ): Promise<Record<P[number], PermissionStatus>>;
   checkNotifications(): Promise<NotificationsResponse>;
-  openContactsPicker(): Promise<void>;
+  openContactPicker(): Promise<void>;
   openPhotoPicker(): Promise<void>;
   openSettings(type?: 'application' | 'alarms' | 'fullscreen' | 'notifications'): Promise<void>;
   request(permission: Permission, rationale?: Rationale): Promise<PermissionStatus>;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -17,6 +17,7 @@ export type Contract = {
     permissions: P,
   ): Promise<Record<P[number], PermissionStatus>>;
   checkNotifications(): Promise<NotificationsResponse>;
+  openContactsPicker(): Promise<void>;
   openPhotoPicker(): Promise<void>;
   openSettings(type?: 'application' | 'alarms' | 'fullscreen' | 'notifications'): Promise<void>;
   request(permission: Permission, rationale?: Rationale): Promise<PermissionStatus>;

--- a/src/extras/mock.ts
+++ b/src/extras/mock.ts
@@ -17,6 +17,7 @@ export const canScheduleExactAlarms = jest.fn(async () => true);
 export const canUseFullScreenIntent = jest.fn(async () => true);
 export const check = jest.fn(async () => RESULTS.GRANTED);
 export const checkLocationAccuracy = jest.fn(async () => 'full');
+export const openContactsPicker = jest.fn(async () => {});
 export const openPhotoPicker = jest.fn(async () => {});
 export const openSettings = jest.fn(async () => {});
 export const request = jest.fn(async () => RESULTS.GRANTED);
@@ -91,6 +92,7 @@ export default {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
+  openContactsPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/extras/mock.ts
+++ b/src/extras/mock.ts
@@ -17,7 +17,7 @@ export const canScheduleExactAlarms = jest.fn(async () => true);
 export const canUseFullScreenIntent = jest.fn(async () => true);
 export const check = jest.fn(async () => RESULTS.GRANTED);
 export const checkLocationAccuracy = jest.fn(async () => 'full');
-export const openContactsPicker = jest.fn(async () => {});
+export const openContactPicker = jest.fn(async () => {});
 export const openPhotoPicker = jest.fn(async () => {});
 export const openSettings = jest.fn(async () => {});
 export const request = jest.fn(async () => RESULTS.GRANTED);
@@ -92,7 +92,7 @@ export default {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export const check = methods.check;
 export const checkLocationAccuracy = methods.checkLocationAccuracy;
 export const checkMultiple = methods.checkMultiple;
 export const checkNotifications = methods.checkNotifications;
-export const openContactsPicker = methods.openContactsPicker;
+export const openContactPicker = methods.openContactPicker;
 export const openPhotoPicker = methods.openPhotoPicker;
 export const openSettings = methods.openSettings;
 export const request = methods.request;
@@ -31,7 +31,7 @@ export default {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export const check = methods.check;
 export const checkLocationAccuracy = methods.checkLocationAccuracy;
 export const checkMultiple = methods.checkMultiple;
 export const checkNotifications = methods.checkNotifications;
+export const openContactsPicker = methods.openContactsPicker;
 export const openPhotoPicker = methods.openPhotoPicker;
 export const openSettings = methods.openSettings;
 export const request = methods.request;
@@ -30,6 +31,7 @@ export default {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
+  openContactsPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/methods.android.ts
+++ b/src/methods.android.ts
@@ -4,6 +4,7 @@ import NativeModule from './specs/NativeRNPermissions';
 import type {NotificationsResponse, Permission, PermissionStatus, Rationale} from './types';
 import {
   checkLocationAccuracy,
+  openContactsPicker,
   openPhotoPicker,
   requestLocationAccuracy,
 } from './unsupportedMethods';
@@ -98,6 +99,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
+  openContactsPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/methods.android.ts
+++ b/src/methods.android.ts
@@ -4,7 +4,7 @@ import NativeModule from './specs/NativeRNPermissions';
 import type {NotificationsResponse, Permission, PermissionStatus, Rationale} from './types';
 import {
   checkLocationAccuracy,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   requestLocationAccuracy,
 } from './unsupportedMethods';
@@ -99,7 +99,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/methods.ios.ts
+++ b/src/methods.ios.ts
@@ -4,8 +4,8 @@ import type {LocationAccuracy, NotificationsResponse, PermissionStatus} from './
 import {canScheduleExactAlarms, canUseFullScreenIntent} from './unsupportedMethods';
 import {uniq} from './utils';
 
-const openContactsPicker: Contract['openContactsPicker'] = async () => {
-  await NativeModule.openContactsPicker();
+const openContactPicker: Contract['openContactPicker'] = async () => {
+  await NativeModule.openContactPicker();
 };
 
 const openPhotoPicker: Contract['openPhotoPicker'] = async () => {
@@ -75,7 +75,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/methods.ios.ts
+++ b/src/methods.ios.ts
@@ -4,6 +4,10 @@ import type {LocationAccuracy, NotificationsResponse, PermissionStatus} from './
 import {canScheduleExactAlarms, canUseFullScreenIntent} from './unsupportedMethods';
 import {uniq} from './utils';
 
+const openContactsPicker: Contract['openContactsPicker'] = async () => {
+  await NativeModule.openContactsPicker();
+};
+
 const openPhotoPicker: Contract['openPhotoPicker'] = async () => {
   await NativeModule.openPhotoPicker();
 };
@@ -71,6 +75,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
+  openContactsPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -3,7 +3,7 @@ import {RESULTS} from './results';
 import type {PermissionStatus} from './types';
 import {
   checkLocationAccuracy,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   requestLocationAccuracy,
 } from './unsupportedMethods';
@@ -33,7 +33,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   openSettings: Promise.reject,
   request: check,

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -3,6 +3,7 @@ import {RESULTS} from './results';
 import type {PermissionStatus} from './types';
 import {
   checkLocationAccuracy,
+  openContactsPicker,
   openPhotoPicker,
   requestLocationAccuracy,
 } from './unsupportedMethods';
@@ -32,6 +33,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
+  openContactsPicker,
   openPhotoPicker,
   openSettings: Promise.reject,
   request: check,

--- a/src/methods.windows.ts
+++ b/src/methods.windows.ts
@@ -5,6 +5,7 @@ import {
   canScheduleExactAlarms,
   canUseFullScreenIntent,
   checkLocationAccuracy,
+  openContactsPicker,
   openPhotoPicker,
   requestLocationAccuracy,
 } from './unsupportedMethods';
@@ -56,6 +57,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
+  openContactsPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/methods.windows.ts
+++ b/src/methods.windows.ts
@@ -5,7 +5,7 @@ import {
   canScheduleExactAlarms,
   canUseFullScreenIntent,
   checkLocationAccuracy,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   requestLocationAccuracy,
 } from './unsupportedMethods';
@@ -57,7 +57,7 @@ export const methods: Contract = {
   checkLocationAccuracy,
   checkMultiple,
   checkNotifications,
-  openContactsPicker,
+  openContactPicker,
   openPhotoPicker,
   openSettings,
   request,

--- a/src/specs/NativeRNPermissions.ts
+++ b/src/specs/NativeRNPermissions.ts
@@ -13,7 +13,7 @@ export interface Spec extends TurboModule {
   checkLocationAccuracy(): Promise<string>;
   checkMultiple(permissions: string[]): Promise<Object>;
   checkNotifications(): Promise<NotificationsResponse>;
-  openContactsPicker(): Promise<boolean>;
+  openContactPicker(): Promise<boolean>;
   openPhotoPicker(): Promise<boolean>;
   openSettings(type: string): Promise<void>;
   request(permission: string): Promise<string>;

--- a/src/specs/NativeRNPermissions.ts
+++ b/src/specs/NativeRNPermissions.ts
@@ -13,6 +13,7 @@ export interface Spec extends TurboModule {
   checkLocationAccuracy(): Promise<string>;
   checkMultiple(permissions: string[]): Promise<Object>;
   checkNotifications(): Promise<NotificationsResponse>;
+  openContactsPicker(): Promise<boolean>;
   openPhotoPicker(): Promise<boolean>;
   openSettings(type: string): Promise<void>;
   request(permission: string): Promise<string>;

--- a/src/unsupportedMethods.ts
+++ b/src/unsupportedMethods.ts
@@ -11,6 +11,10 @@ export const canUseFullScreenIntent: Contract['canUseFullScreenIntent'] = async 
   throw getUnsupportedError('Android', 14);
 };
 
+export const openContactsPicker: Contract['openContactsPicker'] = async () => {
+  throw getUnsupportedError('iOS', 18);
+};
+
 export const openPhotoPicker: Contract['openPhotoPicker'] = async () => {
   throw getUnsupportedError('iOS', 14);
 };

--- a/src/unsupportedMethods.ts
+++ b/src/unsupportedMethods.ts
@@ -11,7 +11,7 @@ export const canUseFullScreenIntent: Contract['canUseFullScreenIntent'] = async 
   throw getUnsupportedError('Android', 14);
 };
 
-export const openContactsPicker: Contract['openContactsPicker'] = async () => {
+export const openContactPicker: Contract['openContactPicker'] = async () => {
   throw getUnsupportedError('iOS', 18);
 };
 

--- a/windows/RNPermissions/RNPermissions.cpp
+++ b/windows/RNPermissions/RNPermissions.cpp
@@ -31,6 +31,11 @@ inline void RNPermissions::RNPermissions::OpenSettings(std::wstring type, React:
     });
 }
 
+void RNPermissions::RNPermissions::OpenContactsPicker(React::ReactPromise<bool>&& promise) noexcept {
+  // no-op - iOS 18+ only
+  promise.Resolve(false);
+}
+
 void RNPermissions::RNPermissions::OpenPhotoPicker(React::ReactPromise<bool>&& promise) noexcept {
   // no-op - iOS 14+ only
   promise.Resolve(false);

--- a/windows/RNPermissions/RNPermissions.cpp
+++ b/windows/RNPermissions/RNPermissions.cpp
@@ -31,7 +31,7 @@ inline void RNPermissions::RNPermissions::OpenSettings(std::wstring type, React:
     });
 }
 
-void RNPermissions::RNPermissions::OpenContactsPicker(React::ReactPromise<bool>&& promise) noexcept {
+void RNPermissions::RNPermissions::OpenContactPicker(React::ReactPromise<bool>&& promise) noexcept {
   // no-op - iOS 18+ only
   promise.Resolve(false);
 }

--- a/windows/RNPermissions/RNPermissions.h
+++ b/windows/RNPermissions/RNPermissions.h
@@ -23,6 +23,9 @@ struct RNPermissions
     REACT_METHOD(OpenSettings, L"openSettings");
     void OpenSettings(std::wstring type, React::ReactPromise<void>&& promise) noexcept;
 
+    REACT_METHOD(OpenContactsPicker, L"openContactsPicker");
+    void OpenContactsPicker(React::ReactPromise<bool>&& promise) noexcept;
+
     REACT_METHOD(OpenPhotoPicker, L"openPhotoPicker");
     void OpenPhotoPicker(React::ReactPromise<bool>&& promise) noexcept;
 

--- a/windows/RNPermissions/RNPermissions.h
+++ b/windows/RNPermissions/RNPermissions.h
@@ -23,8 +23,8 @@ struct RNPermissions
     REACT_METHOD(OpenSettings, L"openSettings");
     void OpenSettings(std::wstring type, React::ReactPromise<void>&& promise) noexcept;
 
-    REACT_METHOD(OpenContactsPicker, L"openContactsPicker");
-    void OpenContactsPicker(React::ReactPromise<bool>&& promise) noexcept;
+    REACT_METHOD(OpenContactPicker, L"openContactPicker");
+    void OpenContactPicker(React::ReactPromise<bool>&& promise) noexcept;
 
     REACT_METHOD(OpenPhotoPicker, L"openPhotoPicker");
     void OpenPhotoPicker(React::ReactPromise<bool>&& promise) noexcept;

--- a/windows/RNPermissions/codegen/NativeRNPermissionsSpec.g.h
+++ b/windows/RNPermissions/codegen/NativeRNPermissionsSpec.g.h
@@ -31,6 +31,7 @@ struct RNPermissionsSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(Promise<std::string>) noexcept>{2, L"checkLocationAccuracy"},
       Method<void(std::vector<std::string>, Promise<::React::JSValue>) noexcept>{3, L"checkMultiple"},
       Method<void(Promise<RNPermissionsSpec_NotificationsResponse>) noexcept>{4, L"checkNotifications"},
+      Method<void(Promise<bool>) noexcept>{5, L"openContactsPicker"},
       Method<void(Promise<bool>) noexcept>{5, L"openPhotoPicker"},
       Method<void(std::string, Promise<void>) noexcept>{6, L"openSettings"},
       Method<void(std::string, Promise<std::string>) noexcept>{7, L"request"},
@@ -74,6 +75,11 @@ struct RNPermissionsSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "checkNotifications",
           "    REACT_METHOD(checkNotifications) void checkNotifications(::React::ReactPromise<RNPermissionsSpec_NotificationsResponse> &&result) noexcept { /* implementation */ }\n"
           "    REACT_METHOD(checkNotifications) static void checkNotifications(::React::ReactPromise<RNPermissionsSpec_NotificationsResponse> &&result) noexcept { /* implementation */ }\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+          5,
+          "openContactsPicker",
+          "    REACT_METHOD(openContactsPicker) void openContactsPicker(::React::ReactPromise<bool> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openContactsPicker) static void openContactsPicker(::React::ReactPromise<bool> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "openPhotoPicker",

--- a/windows/RNPermissions/codegen/NativeRNPermissionsSpec.g.h
+++ b/windows/RNPermissions/codegen/NativeRNPermissionsSpec.g.h
@@ -31,7 +31,7 @@ struct RNPermissionsSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(Promise<std::string>) noexcept>{2, L"checkLocationAccuracy"},
       Method<void(std::vector<std::string>, Promise<::React::JSValue>) noexcept>{3, L"checkMultiple"},
       Method<void(Promise<RNPermissionsSpec_NotificationsResponse>) noexcept>{4, L"checkNotifications"},
-      Method<void(Promise<bool>) noexcept>{5, L"openContactsPicker"},
+      Method<void(Promise<bool>) noexcept>{5, L"openContactPicker"},
       Method<void(Promise<bool>) noexcept>{5, L"openPhotoPicker"},
       Method<void(std::string, Promise<void>) noexcept>{6, L"openSettings"},
       Method<void(std::string, Promise<std::string>) noexcept>{7, L"request"},
@@ -77,9 +77,9 @@ struct RNPermissionsSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(checkNotifications) static void checkNotifications(::React::ReactPromise<RNPermissionsSpec_NotificationsResponse> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
-          "openContactsPicker",
-          "    REACT_METHOD(openContactsPicker) void openContactsPicker(::React::ReactPromise<bool> &&result) noexcept { /* implementation */ }\n"
-          "    REACT_METHOD(openContactsPicker) static void openContactsPicker(::React::ReactPromise<bool> &&result) noexcept { /* implementation */ }\n");
+          "openContactPicker",
+          "    REACT_METHOD(openContactPicker) void openContactPicker(::React::ReactPromise<bool> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openContactPicker) static void openContactPicker(::React::ReactPromise<bool> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "openPhotoPicker",


### PR DESCRIPTION
# Summary

iOS 18 added limited contacts access. This adds `openContactsPicker()` to let the user update their selection when the `Contacts` permission is `limited`, same as `openPhotoPicker()` does for the photo library (related: #894, #895).

Apple only exposes this picker as a SwiftUI modifier (`contactAccessPicker`), so the Contacts handler gets a small Swift file presenting it through a `UIHostingController`. The ObjC handler calls it via `NSClassFromString` + a protocol, which works the same with static libs and `use_frameworks!` without touching the module setup. `setup.rb` now globs `*.swift` and links `ContactsUI`, and the podspec declares `swift_version`.

## Test Plan

Tested in the example app on an iPhone 16 Pro simulator (iOS 18.6), with both the default pod install and `USE_FRAMEWORKS=dynamic`.

### What's required for testing (prerequisites)?

An iOS 18+ simulator. `Contacts` is already enabled in the example Podfile.

### What are the steps to test it (after prerequisites)?

- Request `CONTACTS` and pick "Select Contacts" → status is `limited`
- Tap the new toolbar button → the contact access picker opens, edit the selection, tap Done → the promise resolves
- With full access, denied or not determined → rejects with "Contacts permission isn't limited"
- On iOS < 18 → rejects with "Only available on iOS 18 or higher"
- On Android → throws the JS "Only supported by iOS 18 and above" error

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ❌     |

## Checklist

- [ ] I have tested this on a device and a simulator (simulator only)
- [x] I added the documentation in `README.md`
- [x] I added a sample use of the API in the example project (`example/App.tsx`)